### PR TITLE
Extract all metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
-    <api.version>1.0.4-SNAPSHOT</api.version>
-    <impl.version>1.0.8-SNAPSHOT</impl.version>
+    <api.version>1.0.5-SNAPSHOT</api.version>
+    <impl.version>1.0.10-SNAPSHOT</impl.version>
   </properties>
 
   <dependencies>

--- a/telegram-decoder-api/src/main/java/dpf/ap/gpinf/interfacetelegram/DecoderTelegramInterface.java
+++ b/telegram-decoder-api/src/main/java/dpf/ap/gpinf/interfacetelegram/DecoderTelegramInterface.java
@@ -13,6 +13,7 @@ package dpf.ap.gpinf.interfacetelegram;
 
 
 import java.util.List;
+import java.util.Map;
 
 public interface DecoderTelegramInterface {
 
@@ -35,4 +36,6 @@ public interface DecoderTelegramInterface {
     public List<PhotoData> getPhotoData();
 
     public long getDocumentSize();
+
+    public Map<String, Object> getAlltMetadata();
 }

--- a/telegram-decoder-impl/pom.xml
+++ b/telegram-decoder-impl/pom.xml
@@ -18,6 +18,12 @@
       <artifactId>telegram-decoder-api</artifactId>
       <version>${api.version}</version>
     </dependency>
+    <dependency>
+	  <groupId>com.google.code.findbugs</groupId>
+	  <artifactId>jsr305</artifactId>
+	  <version>3.0.2</version>
+	</dependency>
+
   </dependencies>
 
 </project>

--- a/telegram-decoder-impl/src/main/java/android/graphics/Bitmap.java
+++ b/telegram-decoder-impl/src/main/java/android/graphics/Bitmap.java
@@ -1,0 +1,5 @@
+package android.graphics;
+
+public class Bitmap {
+
+}

--- a/telegram-decoder-impl/src/main/java/android/graphics/drawable/BitmapDrawable.java
+++ b/telegram-decoder-impl/src/main/java/android/graphics/drawable/BitmapDrawable.java
@@ -1,0 +1,10 @@
+package android.graphics.drawable;
+
+import android.graphics.Bitmap;
+
+public class BitmapDrawable {
+    public BitmapDrawable(Bitmap a) {
+
+    }
+
+}

--- a/telegram-decoder-impl/src/main/java/android/os/Build.java
+++ b/telegram-decoder-impl/src/main/java/android/os/Build.java
@@ -1,0 +1,9 @@
+package android.os;
+
+public class Build {
+    public static class version {
+        public int SDK_INT = 22;
+    }
+
+    public static version VERSION = new version();
+}

--- a/telegram-decoder-impl/src/main/java/androidx/annotation/Nullable.java
+++ b/telegram-decoder-impl/src/main/java/androidx/annotation/Nullable.java
@@ -1,0 +1,17 @@
+package androidx.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import javax.annotation.Nonnull;
+import javax.annotation.meta.TypeQualifierNickname;
+import javax.annotation.meta.When;
+
+@Documented
+@TypeQualifierNickname
+@Nonnull(when = When.UNKNOWN)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Nullable {
+
+}

--- a/telegram-decoder-impl/src/main/java/org/telegram/messenger/FileLoader.java
+++ b/telegram-decoder-impl/src/main/java/org/telegram/messenger/FileLoader.java
@@ -1,0 +1,9 @@
+package org.telegram.messenger;
+
+import org.telegram.tgnet.TLRPC;
+
+public class FileLoader {
+    public static String getDocumentFileName(TLRPC.Document document) {
+        return null;
+    }
+}

--- a/telegram-decoder-impl/src/main/java/org/telegram/messenger/FileLog.java
+++ b/telegram-decoder-impl/src/main/java/org/telegram/messenger/FileLog.java
@@ -1,0 +1,15 @@
+package org.telegram.messenger;
+
+public class FileLog {
+    public static void e(final String message) {
+        // not implemented
+    }
+
+    public static void e(final Throwable e) {
+        // not implemented
+    }
+
+    public static void e(final String message, final Throwable exception) {
+        // not implemented
+    }
+}

--- a/telegram-decoder-impl/src/main/java/org/telegram/messenger/ImageLoader.java
+++ b/telegram-decoder-impl/src/main/java/org/telegram/messenger/ImageLoader.java
@@ -1,0 +1,9 @@
+package org.telegram.messenger;
+
+import android.graphics.Bitmap;
+
+public class ImageLoader {
+    public static Bitmap getStrippedPhotoBitmap(byte[] photoBytes, String filter) {
+        return null;
+    }
+}

--- a/telegram-decoder-impl/src/main/java/org/telegram/messenger/MessageObject.java
+++ b/telegram-decoder-impl/src/main/java/org/telegram/messenger/MessageObject.java
@@ -1,0 +1,5 @@
+package org.telegram.messenger;
+
+public class MessageObject {
+
+}

--- a/telegram-decoder-impl/src/main/java/org/telegram/messenger/SharedConfig.java
+++ b/telegram-decoder-impl/src/main/java/org/telegram/messenger/SharedConfig.java
@@ -1,0 +1,6 @@
+package org.telegram.messenger;
+
+public class SharedConfig {
+    public static boolean forceRtmpStream;
+
+}

--- a/telegram-decoder-impl/src/main/java/org/telegram/tgnet/TLRPC.java
+++ b/telegram-decoder-impl/src/main/java/org/telegram/tgnet/TLRPC.java
@@ -11,9 +11,18 @@ package org.telegram.tgnet;
 import java.util.ArrayList;
 import java.util.HashMap;
 
+import org.telegram.messenger.BuildVars;
+import org.telegram.messenger.FileLoader;
+import org.telegram.messenger.FileLog;
+import org.telegram.messenger.ImageLoader;
+import org.telegram.messenger.MessageObject;
+import org.telegram.messenger.SharedConfig;
 import org.telegram.messenger.Utilities;
 
-@SuppressWarnings("unchecked")
+import android.graphics.drawable.BitmapDrawable;
+import android.os.Build;
+import androidx.annotation.Nullable;
+
 public class TLRPC {
 
     public static final int USER_FLAG_ACCESS_HASH           = 0x00000001;
@@ -58,11 +67,10 @@ public class TLRPC {
     public static final int MESSAGE_FLAG_HAS_BOT_ID         = 0x00000800;
     public static final int MESSAGE_FLAG_EDITED             = 0x00008000;
 
-    public static final int LAYER = 140;
+    public static final int LAYER = 152;
 
     public static class TL_stats_megagroupStats extends TLObject {
         public static int constructor = 0xef7ff916;
-
         public TL_statsDateRangeDays period;
         public TL_statsAbsValueAndPrev members;
         public TL_statsAbsValueAndPrev messages;
@@ -212,6 +220,196 @@ public class TLRPC {
         }
     }
 
+
+    public static abstract class EmailVerifyPurpose extends TLObject {
+
+        public static EmailVerifyPurpose TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
+            EmailVerifyPurpose result = null;
+            switch (constructor) {
+                case 0x4345be73:
+                    result = new TL_emailVerifyPurposeLoginSetup();
+                    break;
+                case 0x527d22eb:
+                    result = new TL_emailVerifyPurposeLoginChange();
+                    break;
+                case 0xbbf51685:
+                    result = new TL_emailVerifyPurposePassport();
+                    break;
+            }
+            if (result == null && exception) {
+                throw new RuntimeException(String.format("can't parse magic %x in EmailVerifyPurpose", constructor));
+            }
+            if (result != null) {
+                result.readParams(stream, exception);
+            }
+            return result;
+        }
+    }
+
+    public static class TL_emailVerifyPurposeLoginSetup extends EmailVerifyPurpose {
+        public static int constructor = 0x4345be73;
+
+        public String phone_number;
+        public String phone_code_hash;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            phone_number = stream.readString(exception);
+            phone_code_hash = stream.readString(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeString(phone_number);
+            stream.writeString(phone_code_hash);
+        }
+    }
+
+    public static class TL_emailVerifyPurposeLoginChange extends EmailVerifyPurpose {
+        public static int constructor = 0x527d22eb;
+
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
+    public static class TL_emailVerifyPurposePassport extends EmailVerifyPurpose {
+        public static int constructor = 0xbbf51685;
+
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
+    public static abstract class EmailVerification extends TLObject {
+
+        public static EmailVerification TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
+            EmailVerification result = null;
+            switch (constructor) {
+                case 0x922e55a9:
+                    result = new TL_emailVerificationCode();
+                    break;
+                case 0xdb909ec2:
+                    result = new TL_emailVerificationGoogle();
+                    break;
+                case 0x96d074fd:
+                    result = new TL_emailVerificationApple();
+                    break;
+            }
+            if (result == null && exception) {
+                throw new RuntimeException(String.format("can't parse magic %x in EmailVerification", constructor));
+            }
+            if (result != null) {
+                result.readParams(stream, exception);
+            }
+            return result;
+        }
+    }
+
+    public static class TL_emailVerificationCode extends EmailVerification {
+        public static int constructor = 0x922e55a9;
+
+        public String code;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            code = stream.readString(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeString(code);
+        }
+    }
+
+    public static class TL_emailVerificationGoogle extends EmailVerification {
+        public static int constructor = 0xdb909ec2;
+
+        public String token;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            token = stream.readString(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeString(token);
+        }
+    }
+
+    public static class TL_emailVerificationApple extends EmailVerification {
+        public static int constructor = 0x96d074fd;
+
+        public String token;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            token = stream.readString(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeString(token);
+        }
+    }
+
+    public static abstract class account_EmailVerified extends TLObject {
+
+        public static account_EmailVerified TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
+            account_EmailVerified result = null;
+            switch (constructor) {
+                case 0x2b96cd1b:
+                    result = new TL_account_emailVerified();
+                    break;
+                case 0xe1bb0d61:
+                    result = new TL_account_emailVerifiedLogin();
+                    break;
+            }
+            if (result == null && exception) {
+                throw new RuntimeException(String.format("can't parse magic %x in account_EmailVerified", constructor));
+            }
+            if (result != null) {
+                result.readParams(stream, exception);
+            }
+            return result;
+        }
+    }
+
+    public static class TL_account_emailVerified extends account_EmailVerified {
+        public static int constructor = 0x2b96cd1b;
+
+        public String email;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            email = stream.readString(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeString(email);
+        }
+    }
+
+    public static class TL_account_emailVerifiedLogin extends account_EmailVerified {
+        public static int constructor = 0xe1bb0d61;
+
+        public String email;
+        public auth_SentCode sent_code;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            email = stream.readString(exception);
+            sent_code = auth_SentCode.TLdeserialize(stream, stream.readInt32(exception), exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeString(email);
+            sent_code.serializeToStream(stream);
+        }
+    }
+
     public static class TL_chatBannedRights extends TLObject {
         public static int constructor = 0x9f120418;
 
@@ -228,12 +426,22 @@ public class TLRPC {
         public boolean change_info;
         public boolean invite_users;
         public boolean pin_messages;
+        public boolean manage_topics;
+        public boolean send_photos;
+        public boolean send_videos;
+        public boolean send_roundvideos;
+        public boolean send_audios;
+        public boolean send_voices;
+        public boolean send_docs;
+        public boolean send_plain;
         public int until_date;
 
-        public static TL_chatBannedRights TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+        public static TL_chatBannedRights TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
             if (TL_chatBannedRights.constructor != constructor) {
                 if (exception) {
-                    throw new RuntimeException(String.format("can't parse magic %x in TL_chatBannedRights", constructor));
+                    throw new RuntimeException(
+                            String.format("can't parse magic %x in TL_chatBannedRights", constructor));
                 } else {
                     return null;
                 }
@@ -257,23 +465,57 @@ public class TLRPC {
             change_info = (flags & 1024) != 0;
             invite_users = (flags & 32768) != 0;
             pin_messages = (flags & 131072) != 0;
+            manage_topics = (flags & 262144) != 0;
+            send_photos = (flags & 524288) != 0;
+            send_videos = (flags & 1048576) != 0;
+            send_roundvideos = (flags & 2097152) != 0;
+            send_audios = (flags & 4194304) != 0;
+            send_voices = (flags & 8388608) != 0;
+            send_docs = (flags & 16777216) != 0;
+            send_plain = (flags & 33554432) != 0;
+            if (send_media) {
+                send_photos = true;
+                send_videos = true;
+                send_roundvideos = true;
+                send_audios = true;
+                send_voices = true;
+                send_docs = true;
+            }
             until_date = stream.readInt32(exception);
         }
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = view_messages ? (flags | 1) : (flags &~ 1);
-            flags = send_messages ? (flags | 2) : (flags &~ 2);
-            flags = send_media ? (flags | 4) : (flags &~ 4);
-            flags = send_stickers ? (flags | 8) : (flags &~ 8);
-            flags = send_gifs ? (flags | 16) : (flags &~ 16);
-            flags = send_games ? (flags | 32) : (flags &~ 32);
-            flags = send_inline ? (flags | 64) : (flags &~ 64);
-            flags = embed_links ? (flags | 128) : (flags &~ 128);
-            flags = send_polls ? (flags | 256) : (flags &~ 256);
-            flags = change_info ? (flags | 1024) : (flags &~ 1024);
-            flags = invite_users ? (flags | 32768) : (flags &~ 32768);
-            flags = pin_messages ? (flags | 131072) : (flags &~ 131072);
+            if (send_photos && send_videos && send_roundvideos && send_audios && send_voices && send_docs) {
+                send_media = true;
+            } else {
+                send_media = false;
+            }
+            if (send_plain && send_media) {
+                send_messages = true;
+            } else {
+                send_messages = false;
+            }
+            flags = view_messages ? (flags | 1) : (flags & ~1);
+            flags = send_messages ? (flags | 2) : (flags & ~2);
+            flags = send_media ? (flags | 4) : (flags & ~4);
+            flags = send_stickers ? (flags | 8) : (flags & ~8);
+            flags = send_gifs ? (flags | 16) : (flags & ~16);
+            flags = send_games ? (flags | 32) : (flags & ~32);
+            flags = send_inline ? (flags | 64) : (flags & ~64);
+            flags = embed_links ? (flags | 128) : (flags & ~128);
+            flags = send_polls ? (flags | 256) : (flags & ~256);
+            flags = change_info ? (flags | 1024) : (flags & ~1024);
+            flags = invite_users ? (flags | 32768) : (flags & ~32768);
+            flags = pin_messages ? (flags | 131072) : (flags & ~131072);
+            flags = manage_topics ? (flags | 262144) : (flags & ~262144);
+            flags = send_photos ? (flags | 524288) : (flags & ~524288);
+            flags = send_videos ? (flags | 1048576) : (flags & ~1048576);
+            flags = send_roundvideos ? (flags | 2097152) : (flags & ~2097152);
+            flags = send_audios ? (flags | 4194304) : (flags & ~4194304);
+            flags = send_voices ? (flags | 8388608) : (flags & ~8388608);
+            flags = send_docs ? (flags | 16777216) : (flags & ~16777216);
+            flags = send_plain ? (flags | 33554432) : (flags & ~33554432);
             stream.writeInt32(flags);
             stream.writeInt32(until_date);
         }
@@ -284,10 +526,12 @@ public class TLRPC {
 
         public String short_name;
 
-        public static TL_stickers_suggestedShortName TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+        public static TL_stickers_suggestedShortName TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
             if (TL_stickers_suggestedShortName.constructor != constructor) {
                 if (exception) {
-                    throw new RuntimeException(String.format("can't parse magic %x in TL_stickers_suggestedShortName", constructor));
+                    throw new RuntimeException(
+                            String.format("can't parse magic %x in TL_stickers_suggestedShortName", constructor));
                 } else {
                     return null;
                 }
@@ -400,7 +644,7 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = no_webpage ? (flags | 2) : (flags &~ 2);
+            flags = no_webpage ? (flags | 2) : (flags & ~2);
             stream.writeInt32(flags);
             if ((flags & 1) != 0) {
                 stream.writeInt32(reply_to_msg_id);
@@ -427,6 +671,7 @@ public class TLRPC {
         public byte[] stripped_thumb;
         public int dc_id;
         public long photo_id;
+        public BitmapDrawable strippedBitmap;
 
         public static ChatPhoto TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             ChatPhoto result = null;
@@ -478,11 +723,19 @@ public class TLRPC {
             photo_big = new TL_fileLocationToBeDeprecated();
             photo_big.volume_id = -photo_id;
             photo_big.local_id = 'c';
+
+            if (stripped_thumb != null && Build.VERSION.SDK_INT >= 21) {
+                try {
+                    strippedBitmap = new BitmapDrawable(ImageLoader.getStrippedPhotoBitmap(stripped_thumb, "b"));
+                } catch (Throwable e) {
+                    FileLog.e(e);
+                }
+            }
         }
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = has_video ? (flags | 1) : (flags &~ 1);
+            flags = has_video ? (flags | 1) : (flags & ~1);
             stream.writeInt32(flags);
             stream.writeInt64(photo_id);
             if ((flags & 2) != 0) {
@@ -549,7 +802,7 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = has_video ? (flags | 1) : (flags &~ 1);
+            flags = has_video ? (flags | 1) : (flags & ~1);
             stream.writeInt32(flags);
             photo_small.serializeToStream(stream);
             photo_big.serializeToStream(stream);
@@ -568,7 +821,13 @@ public class TLRPC {
             photo_big = FileLocation.TLdeserialize(stream, stream.readInt32(exception), exception);
             if ((flags & 2) != 0) {
                 stripped_thumb = stream.readByteArray(exception);
-
+                if (Build.VERSION.SDK_INT >= 21) {
+                    try {
+                        strippedBitmap = new BitmapDrawable(ImageLoader.getStrippedPhotoBitmap(stripped_thumb, "b"));
+                    } catch (Throwable e) {
+                        FileLog.e(e);
+                    }
+                }
             }
             dc_id = stream.readInt32(exception);
         }
@@ -762,6 +1021,9 @@ public class TLRPC {
         public static NotifyPeer TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             NotifyPeer result = null;
             switch (constructor) {
+                case 0x226e6308:
+                    result = new TL_notifyForumTopic();
+                    break;
                 case 0xd612e8ef:
                     result = new TL_notifyBroadcasts();
                     break;
@@ -782,6 +1044,24 @@ public class TLRPC {
                 result.readParams(stream, exception);
             }
             return result;
+        }
+    }
+
+    public static class TL_notifyForumTopic extends NotifyPeer {
+        public static int constructor = 0x226e6308;
+
+        public Peer peer;
+        public int top_msg_id;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            peer = Peer.TLdeserialize(stream, stream.readInt32(exception), exception);
+            top_msg_id = stream.readInt32(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            peer.serializeToStream(stream);
+            stream.writeInt32(top_msg_id);
         }
     }
 
@@ -1025,6 +1305,151 @@ public class TLRPC {
             stream.writeInt32(constructor);
             stream.writeInt32(date);
             file.serializeToStream(stream);
+        }
+    }
+
+    public static class TL_premiumSubscriptionOption extends TLObject {
+        public static int constructor = 0x5f2d1df2;
+
+        public int flags;
+        public boolean current;
+        public String transaction;
+        public boolean can_purchase_upgrade;
+        public int months;
+        public String currency;
+        public long amount;
+        public String bot_url;
+        public String store_product;
+
+        public static TL_premiumSubscriptionOption TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
+            TL_premiumSubscriptionOption result = null;
+            switch (constructor) {
+                case 0x5f2d1df2:
+                    result = new TL_premiumSubscriptionOption();
+                    break;
+                case 0xb6f11ebe:
+                    result = new TL_premiumSubscriptionOption_layer151();
+                    break;
+            }
+            if (result == null && exception) {
+                throw new RuntimeException(
+                        String.format("can't parse magic %x in TL_premiumSubscriptionOption", constructor));
+            }
+            if (result != null) {
+                result.readParams(stream, exception);
+            }
+            return result;
+        }
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            current = (flags & 2) != 0;
+            if ((flags & 8) != 0) {
+                transaction = stream.readString(exception);
+            }
+            can_purchase_upgrade = (flags & 4) != 0;
+            months = stream.readInt32(exception);
+            currency = stream.readString(exception);
+            amount = stream.readInt64(exception);
+            bot_url = stream.readString(exception);
+            if ((flags & 1) != 0) {
+                store_product = stream.readString(exception);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = current ? (flags | 2) : (flags & ~2);
+            flags = can_purchase_upgrade ? (flags | 4) : (flags & ~4);
+            stream.writeInt32(flags);
+            if ((flags & 8) != 0) {
+                stream.writeString(transaction);
+            }
+            stream.writeInt32(months);
+            stream.writeString(currency);
+            stream.writeInt64(amount);
+            stream.writeString(bot_url);
+            if ((flags & 1) != 0) {
+                stream.writeString(store_product);
+            }
+        }
+    }
+
+    public static class TL_premiumSubscriptionOption_layer151 extends TL_premiumSubscriptionOption {
+        public static int constructor = 0xb6f11ebe;
+
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            months = stream.readInt32(exception);
+            currency = stream.readString(exception);
+            amount = stream.readInt64(exception);
+            bot_url = stream.readString(exception);
+            if ((flags & 1) != 0) {
+                store_product = stream.readString(exception);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(flags);
+            stream.writeInt32(months);
+            stream.writeString(currency);
+            stream.writeInt64(amount);
+            stream.writeString(bot_url);
+            if ((flags & 1) != 0) {
+                stream.writeString(store_product);
+            }
+        }
+    }
+
+    public static class TL_premiumGiftOption extends TLObject {
+        public static int constructor = 0x74c34319;
+
+        public int flags;
+        public int months;
+        public String currency;
+        public long amount;
+        public String bot_url;
+        public String store_product;
+
+        public static TL_premiumGiftOption TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
+            if (TL_premiumGiftOption.constructor != constructor) {
+                if (exception) {
+                    throw new RuntimeException(
+                            String.format("can't parse magic %x in TL_premiumGiftOption", constructor));
+                } else {
+                    return null;
+                }
+            }
+            TL_premiumGiftOption result = new TL_premiumGiftOption();
+            result.readParams(stream, exception);
+            return result;
+        }
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            months = stream.readInt32(exception);
+            currency = stream.readString(exception);
+            amount = stream.readInt64(exception);
+            bot_url = stream.readString(exception);
+            if ((flags & 1) != 0) {
+                store_product = stream.readString(exception);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(flags);
+            stream.writeInt32(months);
+            stream.writeString(currency);
+            stream.writeInt64(amount);
+            stream.writeString(bot_url);
+            if ((flags & 1) != 0) {
+                stream.writeString(store_product);
+            }
         }
     }
 
@@ -1305,6 +1730,9 @@ public class TLRPC {
                 case 0x9852f9c6:
                     result = new TL_documentAttributeAudio();
                     break;
+                case 0xfd149899:
+                    result = new TL_documentAttributeCustomEmoji();
+                    break;
             }
             if (result == null && exception) {
                 throw new RuntimeException(String.format("can't parse magic %x in DocumentAttribute", constructor));
@@ -1538,6 +1966,30 @@ public class TLRPC {
             if ((flags & 4) != 0) {
                 stream.writeByteArray(waveform);
             }
+        }
+    }
+
+    public static class TL_documentAttributeCustomEmoji extends DocumentAttribute {
+        public static int constructor = 0xfd149899;
+
+        public boolean free;
+        public boolean text_color;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            free = (flags & 1) != 0;
+            text_color = (flags & 2) != 0;
+            alt = stream.readString(exception);
+            stickerset = InputStickerSet.TLdeserialize(stream, stream.readInt32(exception), exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = free ? (flags | 1) : (flags & ~1);
+            flags = text_color ? (flags | 2) : (flags & ~2);
+            stream.writeInt32(flags);
+            stream.writeString(alt);
+            stickerset.serializeToStream(stream);
         }
     }
 
@@ -2058,7 +2510,9 @@ public class TLRPC {
             record_video_active = (flags & 2048) != 0;
             rtmp_stream = (flags & 4096) != 0;
             listeners_hidden = (flags & 8192) != 0;
-
+            if (SharedConfig.forceRtmpStream) {
+                rtmp_stream = true;
+            }
             id = stream.readInt64(exception);
             access_hash = stream.readInt64(exception);
             participants_count = stream.readInt32(exception);
@@ -2228,14 +2682,17 @@ public class TLRPC {
         public boolean big;
         public boolean unread;
         public Peer peer_id;
-        public String reaction;
+        public Reaction reaction;
 
-        public static TL_messagePeerReaction TLdeserialize(AbstractSerializedData stream, int constructor,
+        public static MessagePeerReaction TLdeserialize(AbstractSerializedData stream, int constructor,
                 boolean exception) {
-            TL_messagePeerReaction result = null;
+            MessagePeerReaction result = null;
             switch (constructor) {
-                case 0x51b67eff:
+                case 0xb156fe9c:
                     result = new TL_messagePeerReaction();
+                    break;
+                case 0x51b67eff:
+                    result = new TL_messagePeerReaction_layer144();
                     break;
                 case 0x932844fa:
                     result = new TL_messagePeerReaction_layer137();
@@ -2252,14 +2709,14 @@ public class TLRPC {
     }
 
     public static class TL_messagePeerReaction extends MessagePeerReaction {
-        public static int constructor = 0x51b67eff;
+        public static int constructor = 0xb156fe9c;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             flags = stream.readInt32(exception);
             big = (flags & 1) != 0;
             unread = (flags & 2) != 0;
             peer_id = Peer.TLdeserialize(stream, stream.readInt32(exception), exception);
-            reaction = stream.readString(exception);
+            reaction = Reaction.TLdeserialize(stream, stream.readInt32(exception), exception);
         }
 
         public void serializeToStream(AbstractSerializedData stream) {
@@ -2268,18 +2725,44 @@ public class TLRPC {
             flags = unread ? (flags | 2) : (flags & ~2);
             stream.writeInt32(flags);
             peer_id.serializeToStream(stream);
-            stream.writeString(reaction);
+            reaction.serializeToStream(stream);
         }
     }
 
-    public static class TL_messagePeerReaction_layer137 extends TL_messagePeerReaction {
+    public static class TL_messagePeerReaction_layer144 extends MessagePeerReaction {
+        public static int constructor = 0x51b67eff;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            big = (flags & 1) != 0;
+            unread = (flags & 2) != 0;
+            peer_id = Peer.TLdeserialize(stream, stream.readInt32(exception), exception);
+            reaction = new TL_reactionEmoji();
+            ((TL_reactionEmoji) reaction).emoticon = stream.readString(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = big ? (flags | 1) : (flags & ~1);
+            flags = unread ? (flags | 2) : (flags & ~2);
+            stream.writeInt32(flags);
+            peer_id.serializeToStream(stream);
+            if (reaction instanceof TL_reactionEmoji)
+                stream.writeString(((TL_reactionEmoji) reaction).emoticon);
+            else
+                stream.writeString("");
+        }
+    }
+
+    public static class TL_messagePeerReaction_layer137 extends MessagePeerReaction {
         public static int constructor = 0x932844fa;
 
         public long user_id;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             user_id = stream.readInt64(exception);
-            reaction = stream.readString(exception);
+            reaction = new TL_reactionEmoji();
+            ((TL_reactionEmoji) reaction).emoticon = stream.readString(exception);
             peer_id = new TL_peerUser();
             peer_id.user_id = user_id;
         }
@@ -2287,7 +2770,10 @@ public class TLRPC {
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
             stream.writeInt64(user_id);
-            stream.writeString(reaction);
+            if (reaction instanceof TL_reactionEmoji)
+                stream.writeString(((TL_reactionEmoji) reaction).emoticon);
+            else
+                stream.writeString("");
         }
     }
 
@@ -2299,7 +2785,10 @@ public class TLRPC {
                 case 0x44747e9a:
                     result = new TL_auth_authorizationSignUpRequired();
                     break;
-                case 0x33fb7bb8:
+                case 0x33fb7bb8:// TODO old constructor need remove
+                    result = new TL_auth_authorization();
+                    break;
+                case 0x2ea2c0d4:
                     result = new TL_auth_authorization();
                     break;
             }
@@ -2336,12 +2825,13 @@ public class TLRPC {
     }
 
     public static class TL_auth_authorization extends auth_Authorization {
-        public static int constructor = 0x33fb7bb8;
+        public static int constructor = 0x2ea2c0d4;
 
         public int flags;
         public boolean setup_password_required;
         public int otherwise_relogin_days;
         public int tmp_sessions;
+        public byte[] future_auth_token;
         public User user;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
@@ -2352,6 +2842,9 @@ public class TLRPC {
             }
             if ((flags & 1) != 0) {
                 tmp_sessions = stream.readInt32(exception);
+            }
+            if ((flags & 4) != 0) {
+                future_auth_token = stream.readByteArray(exception);
             }
             user = User.TLdeserialize(stream, stream.readInt32(exception), exception);
         }
@@ -2365,6 +2858,9 @@ public class TLRPC {
             }
             if ((flags & 1) != 0) {
                 stream.writeInt32(tmp_sessions);
+            }
+            if ((flags & 4) != 0) {
+                stream.writeByteArray(future_auth_token);
             }
             user.serializeToStream(stream);
         }
@@ -2725,12 +3221,14 @@ public class TLRPC {
         public ArrayList<Message> messages = new ArrayList<>();
         public ArrayList<Chat> chats = new ArrayList<>();
         public ArrayList<User> users = new ArrayList<>();
+        public ArrayList<TL_forumTopic> topics = new ArrayList<>();
         public int flags;
         public boolean inexact;
         public int pts;
         public int count;
         public int next_rate;
         public int offset_id_offset;
+        public ArrayList<Document> animatedEmoji;
 
         public static messages_Messages TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             messages_Messages result = null;
@@ -2741,7 +3239,7 @@ public class TLRPC {
                 case 0x8c718e87:
                     result = new TL_messages_messages();
                     break;
-                case 0x64479808:
+                case 0xc776ba4e:
                     result = new TL_messages_channelMessages();
                     break;
                 case 0x74535f21:
@@ -2927,8 +3425,7 @@ public class TLRPC {
     }
 
     public static class TL_messages_channelMessages extends messages_Messages {
-        public static int constructor = 0x64479808;
-
+        public static int constructor = 0xc776ba4e;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             flags = stream.readInt32(exception);
@@ -2952,6 +3449,21 @@ public class TLRPC {
                     return;
                 }
                 messages.add(object);
+            }
+            magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                TL_forumTopic object = TL_forumTopic.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                topics.add(object);
             }
             magic = stream.readInt32(exception);
             if (magic != 0x1cb5c415) {
@@ -2999,6 +3511,12 @@ public class TLRPC {
             stream.writeInt32(count);
             for (int a = 0; a < count; a++) {
                 messages.get(a).serializeToStream(stream);
+            }
+            stream.writeInt32(0x1cb5c415);
+            count = topics.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                topics.get(a).serializeToStream(stream);
             }
             stream.writeInt32(0x1cb5c415);
             count = chats.size();
@@ -3067,20 +3585,24 @@ public class TLRPC {
     }
 
     public static class TL_payments_paymentForm extends TLObject {
-        public static int constructor = 0x1694761b;
+        public static int constructor = 0xa0058751;
 
         public int flags;
         public boolean can_save_credentials;
         public boolean password_missing;
         public long form_id;
         public long bot_id;
+        public String title;
+        public String description;
+        public WebDocument photo;
         public TL_invoice invoice;
         public long provider_id;
         public String url;
         public String native_provider;
         public TL_dataJSON native_params;
+        public ArrayList<TL_paymentFormMethod> additional_methods = new ArrayList<>();
         public TL_paymentRequestedInfo saved_info;
-        public TL_paymentSavedCredentialsCard saved_credentials;
+        public ArrayList<TL_paymentSavedCredentialsCard> saved_credentials = new ArrayList<>();
         public ArrayList<User> users = new ArrayList<>();
 
         public static TL_payments_paymentForm TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
@@ -3102,6 +3624,11 @@ public class TLRPC {
             password_missing = (flags & 8) != 0;
             form_id = stream.readInt64(exception);
             bot_id = stream.readInt64(exception);
+            title = stream.readString(exception);
+            description = stream.readString(exception);
+            if ((flags & 32) != 0) {
+                photo = WebDocument.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
             invoice = TL_invoice.TLdeserialize(stream, stream.readInt32(exception), exception);
             provider_id = stream.readInt64(exception);
             url = stream.readString(exception);
@@ -3111,11 +3638,44 @@ public class TLRPC {
             if ((flags & 16) != 0) {
                 native_params = TL_dataJSON.TLdeserialize(stream, stream.readInt32(exception), exception);
             }
+            if ((flags & 64) != 0) {
+                int magic = stream.readInt32(exception);
+                if (magic != 0x1cb5c415) {
+                    if (exception) {
+                        throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                    }
+                    return;
+                }
+                int count = stream.readInt32(exception);
+                for (int a = 0; a < count; a++) {
+                    TL_paymentFormMethod object = TL_paymentFormMethod.TLdeserialize(stream,
+                            stream.readInt32(exception), exception);
+                    if (object == null) {
+                        return;
+                    }
+                    additional_methods.add(object);
+                }
+            }
             if ((flags & 1) != 0) {
                 saved_info = TL_paymentRequestedInfo.TLdeserialize(stream, stream.readInt32(exception), exception);
             }
             if ((flags & 2) != 0) {
-                saved_credentials = TL_paymentSavedCredentialsCard.TLdeserialize(stream, stream.readInt32(exception), exception);
+                int magic = stream.readInt32(exception);
+                if (magic != 0x1cb5c415) {
+                    if (exception) {
+                        throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                    }
+                    return;
+                }
+                int count = stream.readInt32(exception);
+                for (int a = 0; a < count; a++) {
+                    TL_paymentSavedCredentialsCard object = TL_paymentSavedCredentialsCard.TLdeserialize(stream,
+                            stream.readInt32(exception), exception);
+                    if (object == null) {
+                        return;
+                    }
+                    saved_credentials.add(object);
+                }
             }
             int magic = stream.readInt32(exception);
             if (magic != 0x1cb5c415) {
@@ -3141,6 +3701,11 @@ public class TLRPC {
             stream.writeInt32(flags);
             stream.writeInt64(form_id);
             stream.writeInt64(bot_id);
+            stream.writeString(title);
+            stream.writeString(description);
+            if ((flags & 32) != 0) {
+                photo.serializeToStream(stream);
+            }
             invoice.serializeToStream(stream);
             stream.writeInt64(provider_id);
             stream.writeString(url);
@@ -3150,11 +3715,24 @@ public class TLRPC {
             if ((flags & 16) != 0) {
                 native_params.serializeToStream(stream);
             }
+            if ((flags & 64) != 0) {
+                stream.writeInt32(0x1cb5c415);
+                int count = additional_methods.size();
+                stream.writeInt32(count);
+                for (int a = 0; a < count; a++) {
+                    additional_methods.get(a).serializeToStream(stream);
+                }
+            }
             if ((flags & 1) != 0) {
                 saved_info.serializeToStream(stream);
             }
             if ((flags & 2) != 0) {
-                saved_credentials.serializeToStream(stream);
+                stream.writeInt32(0x1cb5c415);
+                int count = saved_credentials.size();
+                stream.writeInt32(count);
+                for (int a = 0; a < count; a++) {
+                    saved_credentials.get(a).serializeToStream(stream);
+                }
             }
             stream.writeInt32(0x1cb5c415);
             int count = users.size();
@@ -3162,6 +3740,39 @@ public class TLRPC {
             for (int a = 0; a < count; a++) {
                 users.get(a).serializeToStream(stream);
             }
+        }
+    }
+
+    public static class TL_paymentFormMethod extends TLObject {
+        public static int constructor = 0x88f8f21b;
+
+        public String url;
+        public String title;
+
+        public static TL_paymentFormMethod TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
+            if (TL_paymentFormMethod.constructor != constructor) {
+                if (exception) {
+                    throw new RuntimeException(
+                            String.format("can't parse magic %x in TL_PaymentFormMethod", constructor));
+                } else {
+                    return null;
+                }
+            }
+            TL_paymentFormMethod result = new TL_paymentFormMethod();
+            result.readParams(stream, exception);
+            return result;
+        }
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            url = stream.readString(exception);
+            title = stream.readString(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeString(url);
+            stream.writeString(title);
         }
     }
 
@@ -3255,15 +3866,18 @@ public class TLRPC {
     public static abstract class EncryptedFile extends TLObject {
         public long id;
         public long access_hash;
-        public int size;
+        public long size;
         public int dc_id;
         public int key_fingerprint;
 
         public static EncryptedFile TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             EncryptedFile result = null;
             switch (constructor) {
-                case 0x4a70994c:
+                case 0xa8008cd8:
                     result = new TL_encryptedFile();
+                    break;
+                case 0x4a70994c:
+                    result = new TL_encryptedFile_layer142();
                     break;
                 case 0xc21f497e:
                     result = new TL_encryptedFileEmpty();
@@ -3280,6 +3894,27 @@ public class TLRPC {
     }
 
     public static class TL_encryptedFile extends EncryptedFile {
+        public static int constructor = 0xa8008cd8;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            id = stream.readInt64(exception);
+            access_hash = stream.readInt64(exception);
+            size = stream.readInt64(exception);
+            dc_id = stream.readInt32(exception);
+            key_fingerprint = stream.readInt32(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt64(id);
+            stream.writeInt64(access_hash);
+            stream.writeInt64(size);
+            stream.writeInt32(dc_id);
+            stream.writeInt32(key_fingerprint);
+        }
+    }
+
+    public static class TL_encryptedFile_layer142 extends EncryptedFile {
         public static int constructor = 0x4a70994c;
 
 
@@ -3295,7 +3930,7 @@ public class TLRPC {
             stream.writeInt32(constructor);
             stream.writeInt64(id);
             stream.writeInt64(access_hash);
-            stream.writeInt32(size);
+            stream.writeInt32((int) size);
             stream.writeInt32(dc_id);
             stream.writeInt32(key_fingerprint);
         }
@@ -3319,20 +3954,20 @@ public class TLRPC {
         public static Peer TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             Peer result = null;
             switch (constructor) {
+                case 0xa2a5371e:
+                    result = new TL_peerChannel();
+                    break;
                 case 0xbddde532:
                     result = new TL_peerChannel_layer131();
                     break;
                 case 0x59511722:
                     result = new TL_peerUser();
                     break;
-                case 0xa2a5371e:
-                    result = new TL_peerChannel();
+                case 0x9db1bc6d:
+                    result = new TL_peerUser_layer131();
                     break;
                 case 0x36c6019a:
                     result = new TL_peerChat();
-                    break;
-                case 0x9db1bc6d:
-                    result = new TL_peerUser_layer131();
                     break;
                 case 0xbad0e5bb:
                     result = new TL_peerChat_layer131();
@@ -3725,6 +4360,7 @@ public class TLRPC {
         public boolean anonymous;
         public boolean manage_call;
         public boolean other;
+        public boolean manage_topics;
 
         public static TL_chatAdminRights TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             if (TL_chatAdminRights.constructor != constructor) {
@@ -3752,6 +4388,7 @@ public class TLRPC {
             anonymous = (flags & 1024) != 0;
             manage_call = (flags & 2048) != 0;
             other = (flags & 4096) != 0;
+            manage_topics = (flags & 8192) != 0;
         }
 
         public void serializeToStream(AbstractSerializedData stream) {
@@ -3767,6 +4404,7 @@ public class TLRPC {
             flags = anonymous ? (flags | 1024) : (flags &~ 1024);
             flags = manage_call ? (flags | 2048) : (flags &~ 2048);
             flags = other ? (flags | 4096) : (flags &~ 4096);
+            flags = manage_topics ? (flags | 8192) : (flags & ~8192);
             stream.writeInt32(flags);
         }
     }
@@ -4159,7 +4797,7 @@ public class TLRPC {
                 case 0x64199744:
                     result = new TL_secureFileEmpty();
                     break;
-                case 0xe0277a62:
+                case 0x7d09c27e:
                     result = new TL_secureFile();
                     break;
             }
@@ -4183,15 +4821,40 @@ public class TLRPC {
     }
 
     public static class TL_secureFile extends SecureFile {
-        public static int constructor = 0xe0277a62;
+        public static int constructor = 0x7d09c27e;
 
         public long id;
         public long access_hash;
-        public int size;
+        public long size;
         public int dc_id;
         public int date;
         public byte[] file_hash;
         public byte[] secret;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            id = stream.readInt64(exception);
+            access_hash = stream.readInt64(exception);
+            size = stream.readInt64(exception);
+            dc_id = stream.readInt32(exception);
+            date = stream.readInt32(exception);
+            file_hash = stream.readByteArray(exception);
+            secret = stream.readByteArray(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt64(id);
+            stream.writeInt64(access_hash);
+            stream.writeInt64(size);
+            stream.writeInt32(dc_id);
+            stream.writeInt32(date);
+            stream.writeByteArray(file_hash);
+            stream.writeByteArray(secret);
+        }
+    }
+
+    public static class TL_secureFile_layer142 extends TL_secureFile {
+        public static int constructor = 0xe0277a62;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             id = stream.readInt64(exception);
@@ -4207,7 +4870,7 @@ public class TLRPC {
             stream.writeInt32(constructor);
             stream.writeInt64(id);
             stream.writeInt64(access_hash);
-            stream.writeInt32(size);
+            stream.writeInt32((int) size);
             stream.writeInt32(dc_id);
             stream.writeInt32(date);
             stream.writeByteArray(file_hash);
@@ -4946,6 +5609,9 @@ public class TLRPC {
                 case 0x42ffd42b:
                     result = new TL_privacyKeyAddedByPhone();
                     break;
+                case 0x697f414:
+                    result = new TL_privacyKeyVoiceMessages();
+                    break;
                 case 0x3d662b7b:
                     result = new TL_privacyKeyPhoneCall();
                     break;
@@ -5007,6 +5673,15 @@ public class TLRPC {
 
     public static class TL_privacyKeyAddedByPhone extends PrivacyKey {
         public static int constructor = 0x42ffd42b;
+
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
+    public static class TL_privacyKeyVoiceMessages extends PrivacyKey {
+        public static int constructor = 0x697f414;
 
 
         public void serializeToStream(AbstractSerializedData stream) {
@@ -6132,9 +6807,19 @@ public class TLRPC {
     }
 
     public static abstract class auth_SentCodeType extends TLObject {
+        public int flags;
+        public String url;
         public int length;
         public String pattern;
         public String prefix;
+        public boolean apple_signin_allowed;
+        public boolean google_signin_allowed;
+        public String email_pattern;
+        public int next_phone_login_date;
+        public byte[] nonce;
+        public String receipt;
+        public int push_timeout;
+        public boolean verifiedFirebase; // custom
 
         public static auth_SentCodeType TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             auth_SentCodeType result = null;
@@ -6145,6 +6830,12 @@ public class TLRPC {
                 case 0x5353e5a7:
                     result = new TL_auth_sentCodeTypeCall();
                     break;
+                case 0x5a159841:
+                    result = new TL_auth_sentCodeTypeEmailCode();
+                    break;
+                case 0xa5491dea:
+                    result = new TL_auth_sentCodeTypeSetUpEmailRequired();
+                    break;
                 case 0xab03c6d9:
                     result = new TL_auth_sentCodeTypeFlashCall();
                     break;
@@ -6153,6 +6844,12 @@ public class TLRPC {
                     break;
                 case 0xc000bba2:
                     result = new TL_auth_sentCodeTypeSms();
+                    break;
+                case 0xd9565c39:
+                    result = new TL_auth_sentCodeTypeFragmentSms();
+                    break;
+                case 0xe57b1432:
+                    result = new TL_auth_sentCodeTypeFirebaseSms();
                     break;
             }
             if (result == null && exception) {
@@ -6190,6 +6887,51 @@ public class TLRPC {
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
             stream.writeInt32(length);
+        }
+    }
+
+    public static class TL_auth_sentCodeTypeEmailCode extends auth_SentCodeType {
+        public static int constructor = 0x5a159841;
+
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            apple_signin_allowed = (flags & 1) != 0;
+            google_signin_allowed = (flags & 2) != 0;
+            email_pattern = stream.readString(exception);
+            length = stream.readInt32(exception);
+            if ((flags & 4) != 0) {
+                next_phone_login_date = stream.readInt32(exception);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = apple_signin_allowed ? (flags | 1) : (flags & ~1);
+            flags = google_signin_allowed ? (flags | 2) : (flags & ~2);
+            stream.writeInt32(flags);
+            stream.writeString(email_pattern);
+            stream.writeInt32(length);
+            if ((flags & 4) != 0) {
+                stream.writeInt32(next_phone_login_date);
+            }
+        }
+    }
+
+    public static class TL_auth_sentCodeTypeSetUpEmailRequired extends auth_SentCodeType {
+        public static int constructor = 0xa5491dea;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            apple_signin_allowed = (flags & 1) != 0;
+            google_signin_allowed = (flags & 2) != 0;
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = apple_signin_allowed ? (flags | 1) : (flags & ~1);
+            flags = google_signin_allowed ? (flags | 2) : (flags & ~2);
+            stream.writeInt32(flags);
         }
     }
 
@@ -6232,6 +6974,56 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+            stream.writeInt32(length);
+        }
+    }
+
+    public static class TL_auth_sentCodeTypeFragmentSms extends auth_SentCodeType {
+        public static int constructor = 0xd9565c39;
+
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            url = stream.readString(exception);
+            length = stream.readInt32(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeString(url);
+            stream.writeInt32(length);
+        }
+    }
+
+    public static class TL_auth_sentCodeTypeFirebaseSms extends auth_SentCodeType {
+        public static int constructor = 0xe57b1432;
+
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            if ((flags & 1) != 0) {
+                nonce = stream.readByteArray(exception);
+            }
+            if ((flags & 2) != 0) {
+                receipt = stream.readString(exception);
+            }
+            if ((flags & 2) != 0) {
+                push_timeout = stream.readInt32(exception);
+            }
+            length = stream.readInt32(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(flags);
+            if ((flags & 1) != 0) {
+                stream.writeByteArray(nonce);
+            }
+            if ((flags & 2) != 0) {
+                stream.writeString(receipt);
+            }
+            if ((flags & 2) != 0) {
+                stream.writeInt32(push_timeout);
+            }
             stream.writeInt32(length);
         }
     }
@@ -7160,7 +7952,136 @@ public class TLRPC {
         }
     }
 
+    public static class MessageExtendedMedia extends TLObject {
+
+        public static MessageExtendedMedia TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
+            MessageExtendedMedia result = null;
+            switch (constructor) {
+                case 0xad628cc8:
+                    result = new TL_messageExtendedMediaPreview();
+                    break;
+                case 0xee479c64:
+                    result = new TL_messageExtendedMedia();
+                    break;
+            }
+            if (result == null && exception) {
+                throw new RuntimeException(String.format("can't parse magic %x in MessageExtendedMedia", constructor));
+            }
+            if (result != null) {
+                result.readParams(stream, exception);
+            }
+            return result;
+        }
+
+    }
+
+    public static class TL_messageExtendedMediaPreview extends MessageExtendedMedia {
+        public static int constructor = 0xad628cc8;
+
+        public int flags;
+        public int w;
+        public int h;
+        public PhotoSize thumb;
+        public int video_duration;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            if ((flags & 1) != 0) {
+                w = stream.readInt32(exception);
+            }
+            if ((flags & 1) != 0) {
+                h = stream.readInt32(exception);
+            }
+            if ((flags & 2) != 0) {
+                thumb = PhotoSize.TLdeserialize(0, 0, 0, stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 4) != 0) {
+                video_duration = stream.readInt32(exception);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(flags);
+            if ((flags & 1) != 0) {
+                stream.writeInt32(w);
+            }
+            if ((flags & 1) != 0) {
+                stream.writeInt32(h);
+            }
+            if ((flags & 2) != 0) {
+                thumb.serializeToStream(stream);
+            }
+            if ((flags & 4) != 0) {
+                stream.writeInt32(video_duration);
+            }
+        }
+    }
+
+    public static class TL_messageExtendedMedia extends MessageExtendedMedia {
+        public static int constructor = 0xee479c64;
+
+        public MessageMedia media;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            media = MessageMedia.TLdeserialize(stream, stream.readInt32(exception), exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            media.serializeToStream(stream);
+        }
+    }
+
     public static class TL_messageMediaInvoice extends MessageMedia {
+        public static int constructor = 0xf6a548d3;
+
+        public WebDocument webPhoto;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            shipping_address_requested = (flags & 2) != 0;
+            test = (flags & 8) != 0;
+            title = stream.readString(exception);
+            description = stream.readString(exception);
+            if ((flags & 1) != 0) {
+                webPhoto = WebDocument.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 4) != 0) {
+                receipt_msg_id = stream.readInt32(exception);
+            }
+            currency = stream.readString(exception);
+            total_amount = stream.readInt64(exception);
+            start_param = stream.readString(exception);
+            if ((flags & 16) != 0) {
+                extended_media = MessageExtendedMedia.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = shipping_address_requested ? (flags | 2) : (flags & ~2);
+            flags = test ? (flags | 8) : (flags & ~8);
+            stream.writeInt32(flags);
+            stream.writeString(title);
+            stream.writeString(description);
+            if ((flags & 1) != 0) {
+                webPhoto.serializeToStream(stream);
+            }
+            if ((flags & 4) != 0) {
+                stream.writeInt32(receipt_msg_id);
+            }
+            stream.writeString(currency);
+            stream.writeInt64(total_amount);
+            stream.writeString(start_param);
+            if ((flags & 16) != 0) {
+                extended_media.serializeToStream(stream);
+            }
+        }
+    }
+
+    public static class TL_messageMediaInvoice_layer145 extends TL_messageMediaInvoice {
         public static int constructor = 0x84551347;
 
         public WebDocument photo;
@@ -7285,6 +8206,8 @@ public class TLRPC {
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             flags = stream.readInt32(exception);
+            nopremium = (flags & 8) != 0;
+            spoiler = (flags & 16) != 0;
             if ((flags & 1) != 0) {
                 document = Document.TLdeserialize(stream, stream.readInt32(exception), exception);
             } else {
@@ -7297,6 +8220,9 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+            flags = nopremium ? (flags | 8) : (flags & ~8);
+            flags = spoiler ? (flags | 16) : (flags & ~16);
+            flags = document != null ? (flags | 1) : (flags & ~1);
             stream.writeInt32(flags);
             if ((flags & 1) != 0) {
                 document.serializeToStream(stream);
@@ -7376,6 +8302,7 @@ public class TLRPC {
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             flags = stream.readInt32(exception);
+            spoiler = (flags & 8) != 0;
             if ((flags & 1) != 0) {
                 photo = Photo.TLdeserialize(stream, stream.readInt32(exception), exception);
             } else {
@@ -7388,6 +8315,7 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+            flags = spoiler ? (flags | 8) : (flags & ~8);
             stream.writeInt32(flags);
             if ((flags & 1) != 0) {
                 photo.serializeToStream(stream);
@@ -7445,6 +8373,60 @@ public class TLRPC {
             }
             if ((flags & 4) != 0) {
                 stream.writeInt32(ttl_seconds);
+            }
+        }
+    }
+
+    public static class TL_inputMediaInvoice extends InputMedia {
+        public static int constructor = 0x1f9338fe;
+
+        public int flags;
+        public String title;
+        public String description;
+        public TL_inputWebDocument photo;
+        public TL_invoice invoice;
+        public byte[] payload;
+        public String provider;
+        public TL_dataJSON provider_data;
+        public String start_param;
+        public InputMedia extend_media;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            title = stream.readString(exception);
+            description = stream.readString(exception);
+            if ((flags & 1) != 0) {
+                photo = TL_inputWebDocument.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            invoice = TL_invoice.TLdeserialize(stream, stream.readInt32(exception), exception);
+            payload = stream.readByteArray(exception);
+            provider = stream.readString(exception);
+            provider_data = TL_dataJSON.TLdeserialize(stream, stream.readInt32(exception), exception);
+            if ((flags & 2) != 0) {
+                start_param = stream.readString(exception);
+            }
+            if ((flags & 4) != 0) {
+                extend_media = InputMedia.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(flags);
+            stream.writeString(title);
+            stream.writeString(description);
+            if ((flags & 1) != 0) {
+                photo.serializeToStream(stream);
+            }
+            invoice.serializeToStream(stream);
+            stream.writeByteArray(payload);
+            stream.writeString(provider);
+            provider_data.serializeToStream(stream);
+            if ((flags & 2) != 0) {
+                stream.writeString(start_param);
+            }
+            if ((flags & 4) != 0) {
+                extend_media.serializeToStream(stream);
             }
         }
     }
@@ -7775,27 +8757,50 @@ public class TLRPC {
         }
     }
 
-    public static class TL_auth_sentCode extends TLObject {
-        public static int constructor = 0x5e002502;
+    public static abstract class auth_SentCode extends TLObject {
 
         public int flags;
         public auth_SentCodeType type;
         public String phone_code_hash;
         public auth_CodeType next_type;
         public int timeout;
+        public auth_Authorization authorization;
 
-        public static TL_auth_sentCode TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
-            if (TL_auth_sentCode.constructor != constructor) {
-                if (exception) {
-                    throw new RuntimeException(String.format("can't parse magic %x in TL_auth_sentCode", constructor));
-                } else {
-                    return null;
-                }
+        public static auth_SentCode TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+            auth_SentCode result = null;
+            switch (constructor) {
+                case 0x2390fe44:
+                    result = new TL_auth_sentCodeSuccess();
+                    break;
+                case 0x5e002502:
+                    result = new TL_auth_sentCode();
+                    break;
             }
-            TL_auth_sentCode result = new TL_auth_sentCode();
-            result.readParams(stream, exception);
+            if (result == null && exception) {
+                throw new RuntimeException(String.format("can't parse magic %x in auth_SentCode", constructor));
+            }
+            if (result != null) {
+                result.readParams(stream, exception);
+            }
             return result;
         }
+    }
+
+    public static class TL_auth_sentCodeSuccess extends auth_SentCode {
+        public static int constructor = 0x2390fe44;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            authorization = auth_Authorization.TLdeserialize(stream, stream.readInt32(exception), exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            authorization.serializeToStream(stream);
+        }
+    }
+
+    public static class TL_auth_sentCode extends auth_SentCode {
+        public static int constructor = 0x5e002502;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             flags = stream.readInt32(exception);
@@ -7953,6 +8958,7 @@ public class TLRPC {
     public static class TL_notificationSoundDefault extends NotificationSound {
         public static int constructor = 0x97e8bebe;
 
+
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
         }
@@ -7960,6 +8966,7 @@ public class TLRPC {
 
     public static class TL_notificationSoundNone extends NotificationSound {
         public static int constructor = 0x6f0c34df;
+
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
@@ -8595,6 +9602,338 @@ public class TLRPC {
         }
     }
 
+    public static class TL_help_premiumPromo_layer144 extends TL_help_premiumPromo {
+        public static int constructor = 0x8a4f3c29;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            status_text = stream.readString(exception);
+            int magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            int count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                MessageEntity object = MessageEntity.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                status_entities.add(object);
+            }
+            magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                video_sections.add(stream.readString(exception));
+            }
+            magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                Document object = Document.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                videos.add(object);
+            }
+            currency = stream.readString(exception);
+            monthly_amount = stream.readInt64(exception);
+            magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                User object = User.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                users.add(object);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeString(status_text);
+            stream.writeInt32(0x1cb5c415);
+            int count = status_entities.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                status_entities.get(a).serializeToStream(stream);
+            }
+            stream.writeInt32(0x1cb5c415);
+            count = video_sections.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                stream.writeString(video_sections.get(a));
+            }
+            stream.writeInt32(0x1cb5c415);
+            count = videos.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                videos.get(a).serializeToStream(stream);
+            }
+            stream.writeString(currency);
+            stream.writeInt64(monthly_amount);
+            stream.writeInt32(0x1cb5c415);
+            count = users.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                users.get(a).serializeToStream(stream);
+            }
+        }
+    }
+
+    public static class TL_help_premiumPromo_layer140 extends TL_help_premiumPromo {
+        public static int constructor = 0xe0360f1b;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            status_text = stream.readString(exception);
+            int magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            int count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                MessageEntity object = MessageEntity.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                status_entities.add(object);
+            }
+            magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                video_sections.add(stream.readString(exception));
+            }
+            magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                Document object = Document.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                videos.add(object);
+            }
+            currency = stream.readString(exception);
+            monthly_amount = stream.readInt64(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeString(status_text);
+            stream.writeInt32(0x1cb5c415);
+            int count = status_entities.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                status_entities.get(a).serializeToStream(stream);
+            }
+            stream.writeInt32(0x1cb5c415);
+            count = video_sections.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                stream.writeString(video_sections.get(a));
+            }
+            stream.writeInt32(0x1cb5c415);
+            count = videos.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                videos.get(a).serializeToStream(stream);
+            }
+            stream.writeString(currency);
+            stream.writeInt64(monthly_amount);
+        }
+    }
+
+    public static class TL_help_premiumPromo extends TLObject {
+        public static int constructor = 0x5334759c;
+
+        public String status_text;
+        public ArrayList<MessageEntity> status_entities = new ArrayList<>();
+        public ArrayList<String> video_sections = new ArrayList<>();
+        public ArrayList<Document> videos = new ArrayList<>();
+        public ArrayList<TL_premiumSubscriptionOption> period_options = new ArrayList<>();
+        public ArrayList<User> users = new ArrayList<>();
+        public String currency;
+        public long monthly_amount;
+
+        public static TL_help_premiumPromo TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
+            TL_help_premiumPromo result = null;
+            switch (constructor) {
+                case 0x5334759c:
+                    result = new TL_help_premiumPromo();
+                    break;
+                case 0x8a4f3c29:
+                    result = new TL_help_premiumPromo_layer144();
+                    break;
+                case 0xe0360f1b:
+                    result = new TL_help_premiumPromo_layer140();
+                    break;
+            }
+            if (result == null && exception) {
+                throw new RuntimeException(String.format("can't parse magic %x in TL_help_premiumPromo", constructor));
+            }
+            if (result != null) {
+                result.readParams(stream, exception);
+
+                if (result.currency != null) {
+                    TL_help_premiumPromo finalResult = result;
+                    result.period_options.add(new TL_premiumSubscriptionOption() {
+                        {
+                            months = 1;
+                            currency = finalResult.currency;
+                            amount = finalResult.monthly_amount;
+                            store_product = "telegram_premium";
+                        }
+                    });
+                }
+            }
+            return result;
+        }
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            status_text = stream.readString(exception);
+            int magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            int count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                MessageEntity object = MessageEntity.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                status_entities.add(object);
+            }
+            magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                video_sections.add(stream.readString(exception));
+            }
+            magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                Document object = Document.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                videos.add(object);
+            }
+            magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                TL_premiumSubscriptionOption object = TL_premiumSubscriptionOption.TLdeserialize(stream,
+                        stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                period_options.add(object);
+            }
+            magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                User object = User.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                users.add(object);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeString(status_text);
+            stream.writeInt32(0x1cb5c415);
+            int count = status_entities.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                status_entities.get(a).serializeToStream(stream);
+            }
+            stream.writeInt32(0x1cb5c415);
+            count = video_sections.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                stream.writeString(video_sections.get(a));
+            }
+            stream.writeInt32(0x1cb5c415);
+            count = videos.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                videos.get(a).serializeToStream(stream);
+            }
+            stream.writeInt32(0x1cb5c415);
+            count = period_options.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                period_options.get(a).serializeToStream(stream);
+            }
+            stream.writeInt32(0x1cb5c415);
+            count = users.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                users.get(a).serializeToStream(stream);
+            }
+        }
+    }
+
     public static abstract class help_UserInfo extends TLObject {
 
         public static help_UserInfo TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
@@ -8675,10 +10014,12 @@ public class TLRPC {
         public SecureValueType type;
         public byte[] hash;
 
-        public static TL_secureValueHash TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+        public static TL_secureValueHash TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
             if (TL_secureValueHash.constructor != constructor) {
                 if (exception) {
-                    throw new RuntimeException(String.format("can't parse magic %x in TL_secureValueHash", constructor));
+                    throw new RuntimeException(
+                            String.format("can't parse magic %x in TL_secureValueHash", constructor));
                 } else {
                     return null;
                 }
@@ -8704,13 +10045,18 @@ public class TLRPC {
 
         public StickerSet set;
         public ArrayList<TL_stickerPack> packs = new ArrayList<>();
+        public ArrayList<TL_stickerKeyword> keywords = new ArrayList<>();
         public ArrayList<Document> documents = new ArrayList<>();
 
-        public static TL_messages_stickerSet TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+        public static TL_messages_stickerSet TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
             TL_messages_stickerSet result = null;
             switch (constructor) {
-                case 0xb60a24a6:
+                case 0x6e153f16:
                     result = new TL_messages_stickerSet();
+                    break;
+                case 0xb60a24a6:
+                    result = new TL_messages_stickerSet_layer146();
                     break;
                 case 0xd3f924eb:
                     result = new TL_messages_stickerSetNotModified();
@@ -8726,7 +10072,7 @@ public class TLRPC {
         }
     }
 
-    public static class TL_messages_stickerSet extends messages_StickerSet {
+    public static class TL_messages_stickerSet_layer146 extends TL_messages_stickerSet {
         public static int constructor = 0xb60a24a6;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
@@ -8771,6 +10117,83 @@ public class TLRPC {
             stream.writeInt32(count);
             for (int a = 0; a < count; a++) {
                 packs.get(a).serializeToStream(stream);
+            }
+            stream.writeInt32(0x1cb5c415);
+            count = documents.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                documents.get(a).serializeToStream(stream);
+            }
+        }
+    }
+
+    public static class TL_messages_stickerSet extends messages_StickerSet {
+        public static int constructor = 0x6e153f16;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            set = StickerSet.TLdeserialize(stream, stream.readInt32(exception), exception);
+            int magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            int count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                TL_stickerPack object = TL_stickerPack.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                packs.add(object);
+            }
+            magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                TL_stickerKeyword object = TL_stickerKeyword.TLdeserialize(stream, stream.readInt32(exception),
+                        exception);
+                if (object == null) {
+                    return;
+                }
+                keywords.add(object);
+            }
+            magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                Document object = Document.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                documents.add(object);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            set.serializeToStream(stream);
+            stream.writeInt32(0x1cb5c415);
+            int count = packs.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                packs.get(a).serializeToStream(stream);
+            }
+            stream.writeInt32(0x1cb5c415);
+            count = keywords.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                keywords.get(a).serializeToStream(stream);
             }
             stream.writeInt32(0x1cb5c415);
             count = documents.size();
@@ -8854,10 +10277,12 @@ public class TLRPC {
 
         public String message;
 
-        public static TL_help_inviteText TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+        public static TL_help_inviteText TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
             if (TL_help_inviteText.constructor != constructor) {
                 if (exception) {
-                    throw new RuntimeException(String.format("can't parse magic %x in TL_help_inviteText", constructor));
+                    throw new RuntimeException(
+                            String.format("can't parse magic %x in TL_help_inviteText", constructor));
                 } else {
                     return null;
                 }
@@ -9082,7 +10507,8 @@ public class TLRPC {
             }
             int count = stream.readInt32(exception);
             for (int a = 0; a < count; a++) {
-                TL_help_countryCode object = TL_help_countryCode.TLdeserialize(stream, stream.readInt32(exception), exception);
+                TL_help_countryCode object = TL_help_countryCode.TLdeserialize(stream, stream.readInt32(exception),
+                        exception);
                 if (object == null) {
                     return;
                 }
@@ -9092,7 +10518,7 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = hidden ? (flags | 1) : (flags &~ 1);
+            flags = hidden ? (flags | 1) : (flags & ~1);
             stream.writeInt32(flags);
             stream.writeString(iso2);
             stream.writeString(default_name);
@@ -9110,7 +10536,8 @@ public class TLRPC {
 
     public static abstract class SecurePasswordKdfAlgo extends TLObject {
 
-        public static SecurePasswordKdfAlgo TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+        public static SecurePasswordKdfAlgo TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
             SecurePasswordKdfAlgo result = null;
             switch (constructor) {
                 case 0xbbf2dda0:
@@ -9177,10 +10604,12 @@ public class TLRPC {
 
         public long id;
 
-        public static TL_messages_historyImport TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+        public static TL_messages_historyImport TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
             if (TL_messages_historyImport.constructor != constructor) {
                 if (exception) {
-                    throw new RuntimeException(String.format("can't parse magic %x in TL_messages_historyImport", constructor));
+                    throw new RuntimeException(
+                            String.format("can't parse magic %x in TL_messages_historyImport", constructor));
                 } else {
                     return null;
                 }
@@ -9206,10 +10635,16 @@ public class TLRPC {
         public ArrayList<TL_botCommand> commands = new ArrayList<>();
         public int version;
         public BotMenuButton menu_button;
+        public int flags;
+        public Photo description_photo;
+        public Document description_document;
 
         public static BotInfo TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             BotInfo result = null;
             switch (constructor) {
+                case 0xe4169b5d:
+                    result = new TL_botInfo_layer140();
+                    break;
                 case 0xbb2e37ce:
                     result = new TL_botInfoEmpty_layer48();
                     break;
@@ -9222,7 +10657,7 @@ public class TLRPC {
                 case 0x1b74b335:
                     result = new TL_botInfo_layer139();
                     break;
-                case 0xe4169b5d:
+                case 0x8f300b57:
                     result = new TL_botInfo();
                     break;
             }
@@ -9361,7 +10796,77 @@ public class TLRPC {
     }
 
     public static class TL_botInfo extends BotInfo {
+        public static int constructor = 0x8f300b57;
+
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            if ((flags & 1) != 0) {
+                user_id = stream.readInt64(exception);
+            }
+            if ((flags & 2) != 0) {
+                description = stream.readString(exception);
+            }
+            if ((flags & 16) != 0) {
+                description_photo = Photo.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 32) != 0) {
+                description_document = Document.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 4) != 0) {
+                int magic = stream.readInt32(exception);
+                if (magic != 0x1cb5c415) {
+                    if (exception) {
+                        throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                    }
+                    return;
+                }
+                int count = stream.readInt32(exception);
+                for (int a = 0; a < count; a++) {
+                    TL_botCommand object = TL_botCommand.TLdeserialize(stream, stream.readInt32(exception), exception);
+                    if (object == null) {
+                        return;
+                    }
+                    commands.add(object);
+                }
+            }
+            if ((flags & 8) != 0) {
+                menu_button = BotMenuButton.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(flags);
+            if ((flags & 1) != 0) {
+                stream.writeInt64(user_id);
+            }
+            if ((flags & 2) != 0) {
+                stream.writeString(description);
+            }
+            if ((flags & 16) != 0) {
+                description_photo.serializeToStream(stream);
+            }
+            if ((flags & 32) != 0) {
+                description_document.serializeToStream(stream);
+            }
+            if ((flags & 4) != 0) {
+                stream.writeInt32(0x1cb5c415);
+                int count = commands.size();
+                stream.writeInt32(count);
+                for (int a = 0; a < count; a++) {
+                    commands.get(a).serializeToStream(stream);
+                }
+            }
+            if ((flags & 8) != 0) {
+                menu_button.serializeToStream(stream);
+            }
+        }
+    }
+
+    public static class TL_botInfo_layer140 extends TL_botInfo {
         public static int constructor = 0xe4169b5d;
+
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             user_id = stream.readInt64(exception);
@@ -9526,7 +11031,7 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = comments ? (flags | 1) : (flags &~ 1);
+            flags = comments ? (flags | 1) : (flags & ~1);
             stream.writeInt32(flags);
             stream.writeInt32(replies);
             stream.writeInt32(replies_pts);
@@ -9589,7 +11094,7 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = comments ? (flags | 1) : (flags &~ 1);
+            flags = comments ? (flags | 1) : (flags & ~1);
             stream.writeInt32(flags);
             stream.writeInt32(replies);
             stream.writeInt32(replies_pts);
@@ -9613,25 +11118,49 @@ public class TLRPC {
         }
     }
 
-    public static class TL_messages_sponsoredMessages extends TLObject {
-        public static int constructor = 0x65a4c7d5;
-
+    public static abstract class messages_SponsoredMessages extends TLObject {
+        public int flags;
+        public int posts_between;
         public ArrayList<TL_sponsoredMessage> messages = new ArrayList<>();
         public ArrayList<Chat> chats = new ArrayList<>();
         public ArrayList<User> users = new ArrayList<>();
 
-        public static TL_messages_sponsoredMessages TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
-            if (TL_messages_sponsoredMessages.constructor != constructor) {
-                if (exception) {
-                    throw new RuntimeException(String.format("can't parse magic %x in TL_messages_sponsoredMessages", constructor));
-                } else {
-                    return null;
-                }
+        public static messages_SponsoredMessages TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
+            messages_SponsoredMessages result = null;
+            switch (constructor) {
+                case 0x1839490f:
+                    result = new TL_messages_sponsoredMessagesEmpty();
+                    break;
+                case 0xc9ee1d87:
+                    result = new TL_messages_sponsoredMessages();
+                    break;
+                case 0x65a4c7d5:
+                    result = new TL_messages_sponsoredMessagesLayer147();
+                    break;
             }
-            TL_messages_sponsoredMessages result = new TL_messages_sponsoredMessages();
-            result.readParams(stream, exception);
+            if (result == null && exception) {
+                throw new RuntimeException(
+                        String.format("can't parse magic %x in messages_SponsoredMessages", constructor));
+            }
+            if (result != null) {
+                result.readParams(stream, exception);
+            }
             return result;
         }
+    }
+
+    public static class TL_messages_sponsoredMessagesEmpty extends messages_SponsoredMessages {
+        public static int constructor = 0x1839490f;
+
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
+    public static class TL_messages_sponsoredMessagesLayer147 extends messages_SponsoredMessages {
+        public static int constructor = 0xc9ee1d87;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             int magic = stream.readInt32(exception);
@@ -9643,7 +11172,8 @@ public class TLRPC {
             }
             int count = stream.readInt32(exception);
             for (int a = 0; a < count; a++) {
-                TL_sponsoredMessage object = TL_sponsoredMessage.TLdeserialize(stream, stream.readInt32(exception), exception);
+                TL_sponsoredMessage object = TL_sponsoredMessage.TLdeserialize(stream, stream.readInt32(exception),
+                        exception);
                 if (object == null) {
                     return;
                 }
@@ -9683,6 +11213,89 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+            stream.writeInt32(0x1cb5c415);
+            int count = messages.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                messages.get(a).serializeToStream(stream);
+            }
+            stream.writeInt32(0x1cb5c415);
+            count = chats.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                chats.get(a).serializeToStream(stream);
+            }
+            stream.writeInt32(0x1cb5c415);
+            count = users.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                users.get(a).serializeToStream(stream);
+            }
+        }
+    }
+
+    public static class TL_messages_sponsoredMessages extends messages_SponsoredMessages {
+        public static int constructor = 0xc9ee1d87;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            if ((flags & 1) != 0) {
+                posts_between = stream.readInt32(exception);
+            }
+            int magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            int count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                TL_sponsoredMessage object = TL_sponsoredMessage.TLdeserialize(stream, stream.readInt32(exception),
+                        exception);
+                if (object == null) {
+                    return;
+                }
+                messages.add(object);
+            }
+            magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                Chat object = Chat.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                chats.add(object);
+            }
+            magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                User object = User.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                users.add(object);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(flags);
+            if ((flags & 1) != 0) {
+                stream.writeInt32(posts_between);
+            }
             stream.writeInt32(0x1cb5c415);
             int count = messages.size();
             stream.writeInt32(count);
@@ -9812,7 +11425,8 @@ public class TLRPC {
             }
             int count = stream.readInt32(exception);
             for (int a = 0; a < count; a++) {
-                TL_keyboardButtonRow object = TL_keyboardButtonRow.TLdeserialize(stream, stream.readInt32(exception), exception);
+                TL_keyboardButtonRow object = TL_keyboardButtonRow.TLdeserialize(stream, stream.readInt32(exception),
+                        exception);
                 if (object == null) {
                     return;
                 }
@@ -9825,9 +11439,9 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = resize ? (flags | 1) : (flags &~ 1);
-            flags = single_use ? (flags | 2) : (flags &~ 2);
-            flags = selective ? (flags | 4) : (flags &~ 4);
+            flags = resize ? (flags | 1) : (flags & ~1);
+            flags = single_use ? (flags | 2) : (flags & ~2);
+            flags = selective ? (flags | 4) : (flags & ~4);
             stream.writeInt32(flags);
             stream.writeInt32(0x1cb5c415);
             int count = rows.size();
@@ -9852,7 +11466,7 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = selective ? (flags | 4) : (flags &~ 4);
+            flags = selective ? (flags | 4) : (flags & ~4);
             stream.writeInt32(flags);
         }
     }
@@ -9872,8 +11486,8 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = single_use ? (flags | 2) : (flags &~ 2);
-            flags = selective ? (flags | 4) : (flags &~ 4);
+            flags = single_use ? (flags | 2) : (flags & ~2);
+            flags = selective ? (flags | 4) : (flags & ~4);
             stream.writeInt32(flags);
             if ((flags & 8) != 0) {
                 stream.writeString(placeholder);
@@ -9899,7 +11513,8 @@ public class TLRPC {
             }
             int count = stream.readInt32(exception);
             for (int a = 0; a < count; a++) {
-                TL_keyboardButtonRow object = TL_keyboardButtonRow.TLdeserialize(stream, stream.readInt32(exception), exception);
+                TL_keyboardButtonRow object = TL_keyboardButtonRow.TLdeserialize(stream, stream.readInt32(exception),
+                        exception);
                 if (object == null) {
                     return;
                 }
@@ -9909,9 +11524,9 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = resize ? (flags | 1) : (flags &~ 1);
-            flags = single_use ? (flags | 2) : (flags &~ 2);
-            flags = selective ? (flags | 4) : (flags &~ 4);
+            flags = resize ? (flags | 1) : (flags & ~1);
+            flags = single_use ? (flags | 2) : (flags & ~2);
+            flags = selective ? (flags | 4) : (flags & ~4);
             stream.writeInt32(flags);
             stream.writeInt32(0x1cb5c415);
             int count = rows.size();
@@ -9934,8 +11549,8 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = single_use ? (flags | 2) : (flags &~ 2);
-            flags = selective ? (flags | 4) : (flags &~ 4);
+            flags = single_use ? (flags | 2) : (flags & ~2);
+            flags = selective ? (flags | 4) : (flags & ~4);
             stream.writeInt32(flags);
         }
     }
@@ -9954,7 +11569,8 @@ public class TLRPC {
             }
             int count = stream.readInt32(exception);
             for (int a = 0; a < count; a++) {
-                TL_keyboardButtonRow object = TL_keyboardButtonRow.TLdeserialize(stream, stream.readInt32(exception), exception);
+                TL_keyboardButtonRow object = TL_keyboardButtonRow.TLdeserialize(stream, stream.readInt32(exception),
+                        exception);
                 if (object == null) {
                     return;
                 }
@@ -9980,10 +11596,12 @@ public class TLRPC {
         public ArrayList<Document> documents = new ArrayList<>();
         public ThemeSettings settings;
 
-        public static TL_webPageAttributeTheme TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+        public static TL_webPageAttributeTheme TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
             if (TL_webPageAttributeTheme.constructor != constructor) {
                 if (exception) {
-                    throw new RuntimeException(String.format("can't parse magic %x in TL_webPageAttributeTheme", constructor));
+                    throw new RuntimeException(
+                            String.format("can't parse magic %x in TL_webPageAttributeTheme", constructor));
                 } else {
                     return null;
                 }
@@ -10039,7 +11657,8 @@ public class TLRPC {
         public int saved_count;
         public ArrayList<User> users = new ArrayList<>();
 
-        public static contacts_Contacts TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+        public static contacts_Contacts TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
             contacts_Contacts result = null;
             switch (constructor) {
                 case 0xb74ba9d2:
@@ -10126,7 +11745,8 @@ public class TLRPC {
 
     public static abstract class SecureRequiredType extends TLObject {
 
-        public static SecureRequiredType TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+        public static SecureRequiredType TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
             SecureRequiredType result = null;
             switch (constructor) {
                 case 0x829d99da:
@@ -10165,9 +11785,9 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = native_names ? (flags | 1) : (flags &~ 1);
-            flags = selfie_required ? (flags | 2) : (flags &~ 2);
-            flags = translation_required ? (flags | 4) : (flags &~ 4);
+            flags = native_names ? (flags | 1) : (flags & ~1);
+            flags = selfie_required ? (flags | 2) : (flags & ~2);
+            flags = translation_required ? (flags | 4) : (flags & ~4);
             stream.writeInt32(flags);
             type.serializeToStream(stream);
         }
@@ -10188,7 +11808,8 @@ public class TLRPC {
             }
             int count = stream.readInt32(exception);
             for (int a = 0; a < count; a++) {
-                SecureRequiredType object = SecureRequiredType.TLdeserialize(stream, stream.readInt32(exception), exception);
+                SecureRequiredType object = SecureRequiredType.TLdeserialize(stream, stream.readInt32(exception),
+                        exception);
                 if (object == null) {
                     return;
                 }
@@ -10232,6 +11853,9 @@ public class TLRPC {
                     break;
                 case 0xd1219bdd:
                     result = new TL_inputPrivacyKeyAddedByPhone();
+                    break;
+                case 0xaee69d68:
+                    result = new TL_inputPrivacyKeyVoiceMessages();
                     break;
                 case 0xdb9e70d2:
                     result = new TL_inputPrivacyKeyPhoneP2P();
@@ -10301,6 +11925,15 @@ public class TLRPC {
         }
     }
 
+    public static class TL_inputPrivacyKeyVoiceMessages extends InputPrivacyKey {
+        public static int constructor = 0xaee69d68;
+
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
     public static class TL_inputPrivacyKeyProfilePhoto extends InputPrivacyKey {
         public static int constructor = 0x5719bacc;
 
@@ -10324,7 +11957,8 @@ public class TLRPC {
         public ExportedChatInvite invite;
         public ArrayList<User> users = new ArrayList<>();
 
-        public static messages_ExportedChatInvite TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+        public static messages_ExportedChatInvite TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
             messages_ExportedChatInvite result = null;
             switch (constructor) {
                 case 0x222600ef:
@@ -10335,7 +11969,8 @@ public class TLRPC {
                     break;
             }
             if (result == null && exception) {
-                throw new RuntimeException(String.format("can't parse magic %x in messages_ExportedChatInvite", constructor));
+                throw new RuntimeException(
+                        String.format("can't parse magic %x in messages_ExportedChatInvite", constructor));
             }
             if (result != null) {
                 result.readParams(stream, exception);
@@ -10654,9 +12289,13 @@ public class TLRPC {
         public String theme_emoticon;
         public int requests_pending;
         public Peer default_send_as;
-        public ArrayList<String> available_reactions = new ArrayList<>();
+        public ArrayList<String> available_reactions_legacy = new ArrayList<>();
         public int flags2;
         public boolean can_delete_channel;
+        public boolean antispam;
+        public boolean participants_hidden;
+        public boolean translations_disabled;
+        public ChatReactions available_reactions;
 
         public long inviterId; //custom
         public int invitesCount; //custom
@@ -10664,11 +12303,17 @@ public class TLRPC {
         public static ChatFull TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             ChatFull result = null;
             switch (constructor) {
-                case 0xd18ee226:
+                case 0xc9d31138:
                     result = new TL_chatFull();
                     break;
-                case 0xea68a619:
+                case 0xf2355507:
                     result = new TL_channelFull();
+                    break;
+                case 0xd18ee226:
+                    result = new TL_chatFull_layer144();
+                    break;
+                case 0xea68a619:
+                    result = new TL_channelFull_layer144();
                     break;
                 case 0xe13c3d20:
                     result = new TL_channelFull_layer139();
@@ -10778,6 +12423,19 @@ public class TLRPC {
             }
             if (result != null) {
                 result.readParams(stream, exception);
+                if (result.available_reactions == null) {
+                    if (!result.available_reactions_legacy.isEmpty()) {
+                        TL_chatReactionsSome someReactions = new TL_chatReactionsSome();
+                        for (int i = 0; i < result.available_reactions_legacy.size(); i++) {
+                            TL_reactionEmoji reaction = new TL_reactionEmoji();
+                            reaction.emoticon = result.available_reactions_legacy.get(i);
+                            someReactions.reactions.add(reaction);
+                        }
+                        result.available_reactions = someReactions;
+                    } else {
+                        result.available_reactions = new TL_chatReactionsNone();
+                    }
+                }
             }
             return result;
         }
@@ -12819,6 +14477,137 @@ public class TLRPC {
     }
 
     public static class TL_chatFull extends ChatFull {
+        public static int constructor = 0xc9d31138;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            can_set_username = (flags & 128) != 0;
+            has_scheduled = (flags & 256) != 0;
+            id = stream.readInt64(exception);
+            about = stream.readString(exception);
+            participants = ChatParticipants.TLdeserialize(stream, stream.readInt32(exception), exception);
+            if ((flags & 4) != 0) {
+                chat_photo = Photo.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            notify_settings = PeerNotifySettings.TLdeserialize(stream, stream.readInt32(exception), exception);
+            if ((flags & 8192) != 0) {
+                exported_invite = ExportedChatInvite.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 8) != 0) {
+                int magic = stream.readInt32(exception);
+                if (magic != 0x1cb5c415) {
+                    if (exception) {
+                        throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                    }
+                    return;
+                }
+                int count = stream.readInt32(exception);
+                for (int a = 0; a < count; a++) {
+                    BotInfo object = BotInfo.TLdeserialize(stream, stream.readInt32(exception), exception);
+                    if (object == null) {
+                        return;
+                    }
+                    bot_info.add(object);
+                }
+            }
+            if ((flags & 64) != 0) {
+                pinned_msg_id = stream.readInt32(exception);
+            }
+            if ((flags & 2048) != 0) {
+                folder_id = stream.readInt32(exception);
+            }
+            if ((flags & 4096) != 0) {
+                call = TL_inputGroupCall.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 16384) != 0) {
+                ttl_period = stream.readInt32(exception);
+            }
+            if ((flags & 32768) != 0) {
+                groupcall_default_join_as = Peer.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 65536) != 0) {
+                theme_emoticon = stream.readString(exception);
+            }
+            if ((flags & 131072) != 0) {
+                requests_pending = stream.readInt32(exception);
+            }
+            if ((flags & 131072) != 0) {
+                int magic = stream.readInt32(exception);
+                if (magic != 0x1cb5c415) {
+                    if (exception) {
+                        throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                    }
+                    return;
+                }
+                int count = stream.readInt32(exception);
+                for (int a = 0; a < count; a++) {
+                    recent_requesters.add(stream.readInt64(exception));
+                }
+            }
+            if ((flags & 262144) != 0) {
+                available_reactions = ChatReactions.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = can_set_username ? (flags | 128) : (flags &~ 128);
+            flags = has_scheduled ? (flags | 256) : (flags &~ 256);
+            stream.writeInt32(flags);
+            stream.writeInt64(id);
+            stream.writeString(about);
+            participants.serializeToStream(stream);
+            if ((flags & 4) != 0) {
+                chat_photo.serializeToStream(stream);
+            }
+            notify_settings.serializeToStream(stream);
+            if ((flags & 8192) != 0) {
+                exported_invite.serializeToStream(stream);
+            }
+            if ((flags & 8) != 0) {
+                stream.writeInt32(0x1cb5c415);
+                int count = bot_info.size();
+                stream.writeInt32(count);
+                for (int a = 0; a < count; a++) {
+                    bot_info.get(a).serializeToStream(stream);
+                }
+            }
+            if ((flags & 64) != 0) {
+                stream.writeInt32(pinned_msg_id);
+            }
+            if ((flags & 2048) != 0) {
+                stream.writeInt32(folder_id);
+            }
+            if ((flags & 4096) != 0) {
+                call.serializeToStream(stream);
+            }
+            if ((flags & 16384) != 0) {
+                stream.writeInt32(ttl_period);
+            }
+            if ((flags & 32768) != 0) {
+                groupcall_default_join_as.serializeToStream(stream);
+            }
+            if ((flags & 65536) != 0) {
+                stream.writeString(theme_emoticon);
+            }
+            if ((flags & 131072) != 0) {
+                stream.writeInt32(requests_pending);
+            }
+            if ((flags & 131072) != 0) {
+                stream.writeInt32(0x1cb5c415);
+                int count = recent_requesters.size();
+                stream.writeInt32(count);
+                for (int a = 0; a < count; a++) {
+                    stream.writeInt64(recent_requesters.get(a));
+                }
+            }
+            if ((flags & 262144) != 0) {
+                available_reactions.serializeToStream(stream);
+            }
+        }
+    }
+
+    public static class TL_chatFull_layer144 extends ChatFull {
         public static int constructor = 0xd18ee226;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
@@ -12896,15 +14685,15 @@ public class TLRPC {
                 }
                 int count = stream.readInt32(exception);
                 for (int a = 0; a < count; a++) {
-                    available_reactions.add(stream.readString(exception));
+                    available_reactions_legacy.add(stream.readString(exception));
                 }
             }
         }
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = can_set_username ? (flags | 128) : (flags &~ 128);
-            flags = has_scheduled ? (flags | 256) : (flags &~ 256);
+            flags = can_set_username ? (flags | 128) : (flags & ~128);
+            flags = has_scheduled ? (flags | 256) : (flags & ~256);
             stream.writeInt32(flags);
             stream.writeInt64(id);
             stream.writeString(about);
@@ -12955,16 +14744,278 @@ public class TLRPC {
             }
             if ((flags & 262144) != 0) {
                 stream.writeInt32(0x1cb5c415);
-                int count = available_reactions.size();
+                int count = available_reactions_legacy.size();
                 stream.writeInt32(count);
                 for (int a = 0; a < count; a++) {
-                    stream.writeString(available_reactions.get(a));
+                    stream.writeString(available_reactions_legacy.get(a));
                 }
             }
         }
     }
 
     public static class TL_channelFull extends ChatFull {
+        public static int constructor = 0xf2355507;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            can_view_participants = (flags & 8) != 0;
+            can_set_username = (flags & 64) != 0;
+            can_set_stickers = (flags & 128) != 0;
+            hidden_prehistory = (flags & 1024) != 0;
+            can_set_location = (flags & 65536) != 0;
+            has_scheduled = (flags & 524288) != 0;
+            can_view_stats = (flags & 1048576) != 0;
+            blocked = (flags & 4194304) != 0;
+            flags2 = stream.readInt32(exception);
+            can_delete_channel = (flags2 & 1) != 0;
+            antispam = (flags2 & 2) != 0;
+            participants_hidden = (flags2 & 4) != 0;
+            translations_disabled = (flags2 & 8) != 0;
+            id = stream.readInt64(exception);
+            about = stream.readString(exception);
+            if ((flags & 1) != 0) {
+                participants_count = stream.readInt32(exception);
+            }
+            if ((flags & 2) != 0) {
+                admins_count = stream.readInt32(exception);
+            }
+            if ((flags & 4) != 0) {
+                kicked_count = stream.readInt32(exception);
+            }
+            if ((flags & 4) != 0) {
+                banned_count = stream.readInt32(exception);
+            }
+            if ((flags & 8192) != 0) {
+                online_count = stream.readInt32(exception);
+            }
+            read_inbox_max_id = stream.readInt32(exception);
+            read_outbox_max_id = stream.readInt32(exception);
+            unread_count = stream.readInt32(exception);
+            chat_photo = Photo.TLdeserialize(stream, stream.readInt32(exception), exception);
+            notify_settings = PeerNotifySettings.TLdeserialize(stream, stream.readInt32(exception), exception);
+            if ((flags & 8388608) != 0) {
+                exported_invite = ExportedChatInvite.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            int magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            int count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                BotInfo object = BotInfo.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                bot_info.add(object);
+            }
+            if ((flags & 16) != 0) {
+                migrated_from_chat_id = stream.readInt64(exception);
+            }
+            if ((flags & 16) != 0) {
+                migrated_from_max_id = stream.readInt32(exception);
+            }
+            if ((flags & 32) != 0) {
+                pinned_msg_id = stream.readInt32(exception);
+            }
+            if ((flags & 256) != 0) {
+                stickerset = StickerSet.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 512) != 0) {
+                available_min_id = stream.readInt32(exception);
+            }
+            if ((flags & 2048) != 0) {
+                folder_id = stream.readInt32(exception);
+            }
+            if ((flags & 16384) != 0) {
+                linked_chat_id = stream.readInt64(exception);
+            }
+            if ((flags & 32768) != 0) {
+                location = ChannelLocation.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 131072) != 0) {
+                slowmode_seconds = stream.readInt32(exception);
+            }
+            if ((flags & 262144) != 0) {
+                slowmode_next_send_date = stream.readInt32(exception);
+            }
+            if ((flags & 4096) != 0) {
+                stats_dc = stream.readInt32(exception);
+            }
+            pts = stream.readInt32(exception);
+            if ((flags & 2097152) != 0) {
+                call = TL_inputGroupCall.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 16777216) != 0) {
+                ttl_period = stream.readInt32(exception);
+            }
+            if ((flags & 33554432) != 0) {
+                magic = stream.readInt32(exception);
+                if (magic != 0x1cb5c415) {
+                    if (exception) {
+                        throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                    }
+                    return;
+                }
+                count = stream.readInt32(exception);
+                for (int a = 0; a < count; a++) {
+                    pending_suggestions.add(stream.readString(exception));
+                }
+            }
+            if ((flags & 67108864) != 0) {
+                groupcall_default_join_as = Peer.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 134217728) != 0) {
+                theme_emoticon = stream.readString(exception);
+            }
+            if ((flags & 268435456) != 0) {
+                requests_pending = stream.readInt32(exception);
+            }
+            if ((flags & 268435456) != 0) {
+                magic = stream.readInt32(exception);
+                if (magic != 0x1cb5c415) {
+                    if (exception) {
+                        throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                    }
+                    return;
+                }
+                count = stream.readInt32(exception);
+                for (int a = 0; a < count; a++) {
+                    recent_requesters.add(stream.readInt64(exception));
+                }
+            }
+            if ((flags & 536870912) != 0) {
+                default_send_as = Peer.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 1073741824) != 0) {
+                available_reactions = ChatReactions.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = can_view_participants ? (flags | 8) : (flags &~ 8);
+            flags = can_set_username ? (flags | 64) : (flags &~ 64);
+            flags = can_set_stickers ? (flags | 128) : (flags &~ 128);
+            flags = hidden_prehistory ? (flags | 1024) : (flags &~ 1024);
+            flags = can_set_location ? (flags | 65536) : (flags &~ 65536);
+            flags = has_scheduled ? (flags | 524288) : (flags &~ 524288);
+            flags = can_view_stats ? (flags | 1048576) : (flags &~ 1048576);
+            flags = blocked ? (flags | 4194304) : (flags &~ 4194304);
+            stream.writeInt32(flags);
+            flags2 = can_delete_channel ? (flags2 | 1) : (flags2 & ~1);
+            flags2 = antispam ? (flags2 | 2) : (flags2 & ~2);
+            flags2 = participants_hidden ? (flags2 | 4) : (flags2 & ~4);
+            flags2 = translations_disabled ? (flags2 | 8) : (flags2 & ~8);
+            stream.writeInt32(flags2);
+            stream.writeInt64(id);
+            stream.writeString(about);
+            if ((flags & 1) != 0) {
+                stream.writeInt32(participants_count);
+            }
+            if ((flags & 2) != 0) {
+                stream.writeInt32(admins_count);
+            }
+            if ((flags & 4) != 0) {
+                stream.writeInt32(kicked_count);
+            }
+            if ((flags & 4) != 0) {
+                stream.writeInt32(banned_count);
+            }
+            if ((flags & 8192) != 0) {
+                stream.writeInt32(online_count);
+            }
+            stream.writeInt32(read_inbox_max_id);
+            stream.writeInt32(read_outbox_max_id);
+            stream.writeInt32(unread_count);
+            chat_photo.serializeToStream(stream);
+            notify_settings.serializeToStream(stream);
+            if ((flags & 8388608) != 0) {
+                exported_invite.serializeToStream(stream);
+            }
+            stream.writeInt32(0x1cb5c415);
+            int count = bot_info.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                bot_info.get(a).serializeToStream(stream);
+            }
+            if ((flags & 16) != 0) {
+                stream.writeInt64(migrated_from_chat_id);
+            }
+            if ((flags & 16) != 0) {
+                stream.writeInt32(migrated_from_max_id);
+            }
+            if ((flags & 32) != 0) {
+                stream.writeInt32(pinned_msg_id);
+            }
+            if ((flags & 256) != 0) {
+                stickerset.serializeToStream(stream);
+            }
+            if ((flags & 512) != 0) {
+                stream.writeInt32(available_min_id);
+            }
+            if ((flags & 2048) != 0) {
+                stream.writeInt32(folder_id);
+            }
+            if ((flags & 16384) != 0) {
+                stream.writeInt64(linked_chat_id);
+            }
+            if ((flags & 32768) != 0) {
+                location.serializeToStream(stream);
+            }
+            if ((flags & 131072) != 0) {
+                stream.writeInt32(slowmode_seconds);
+            }
+            if ((flags & 262144) != 0) {
+                stream.writeInt32(slowmode_next_send_date);
+            }
+            if ((flags & 4096) != 0) {
+                stream.writeInt32(stats_dc);
+            }
+            stream.writeInt32(pts);
+            if ((flags & 2097152) != 0) {
+                call.serializeToStream(stream);
+            }
+            if ((flags & 16777216) != 0) {
+                stream.writeInt32(ttl_period);
+            }
+            if ((flags & 33554432) != 0) {
+                stream.writeInt32(0x1cb5c415);
+                count = pending_suggestions.size();
+                stream.writeInt32(count);
+                for (int a = 0; a < count; a++) {
+                    stream.writeString(pending_suggestions.get(a));
+                }
+            }
+            if ((flags & 67108864) != 0) {
+                groupcall_default_join_as.serializeToStream(stream);
+            }
+            if ((flags & 134217728) != 0) {
+                stream.writeString(theme_emoticon);
+            }
+            if ((flags & 268435456) != 0) {
+                stream.writeInt32(requests_pending);
+            }
+            if ((flags & 268435456) != 0) {
+                stream.writeInt32(0x1cb5c415);
+                count = recent_requesters.size();
+                stream.writeInt32(count);
+                for (int a = 0; a < count; a++) {
+                    stream.writeInt64(recent_requesters.get(a));
+                }
+            }
+            if ((flags & 536870912) != 0) {
+                default_send_as.serializeToStream(stream);
+            }
+            if ((flags & 1073741824) != 0) {
+                available_reactions.serializeToStream(stream);
+            }
+        }
+    }
+
+    public static class TL_channelFull_layer144 extends ChatFull {
         public static int constructor = 0xea68a619;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
@@ -13107,7 +15158,7 @@ public class TLRPC {
                 }
                 count = stream.readInt32(exception);
                 for (int a = 0; a < count; a++) {
-                    available_reactions.add(stream.readString(exception));
+                    available_reactions_legacy.add(stream.readString(exception));
                 }
             }
         }
@@ -13226,10 +15277,10 @@ public class TLRPC {
             }
             if ((flags & 1073741824) != 0) {
                 stream.writeInt32(0x1cb5c415);
-                count = available_reactions.size();
+                count = available_reactions_legacy.size();
                 stream.writeInt32(count);
                 for (int a = 0; a < count; a++) {
-                    stream.writeString(available_reactions.get(a));
+                    stream.writeString(available_reactions_legacy.get(a));
                 }
             }
         }
@@ -13376,7 +15427,7 @@ public class TLRPC {
                 }
                 count = stream.readInt32(exception);
                 for (int a = 0; a < count; a++) {
-                    available_reactions.add(stream.readString(exception));
+                    available_reactions_legacy.add(stream.readString(exception));
                 }
             }
         }
@@ -13493,10 +15544,10 @@ public class TLRPC {
             }
             if ((flags & 1073741824) != 0) {
                 stream.writeInt32(0x1cb5c415);
-                count = available_reactions.size();
+                count = available_reactions_legacy.size();
                 stream.writeInt32(count);
                 for (int a = 0; a < count; a++) {
-                    stream.writeString(available_reactions.get(a));
+                    stream.writeString(available_reactions_legacy.get(a));
                 }
             }
         }
@@ -13812,9 +15863,9 @@ public class TLRPC {
             flags = can_set_stickers ? (flags | 128) : (flags &~ 128);
             flags = hidden_prehistory ? (flags | 1024) : (flags &~ 1024);
             flags = can_set_location ? (flags | 65536) : (flags &~ 65536);
-            flags = has_scheduled ? (flags | 524288) : (flags &~ 524288);
-            flags = can_view_stats ? (flags | 1048576) : (flags &~ 1048576);
-            flags = blocked ? (flags | 4194304) : (flags &~ 4194304);
+            flags = has_scheduled ? (flags | 524288) : (flags & ~524288);
+            flags = can_view_stats ? (flags | 1048576) : (flags & ~1048576);
+            flags = blocked ? (flags | 4194304) : (flags & ~4194304);
             stream.writeInt32(flags);
             stream.writeInt32((int) id);
             stream.writeString(about);
@@ -13986,7 +16037,7 @@ public class TLRPC {
             flags = can_set_username ? (flags | 64) : (flags &~ 64);
             flags = can_set_stickers ? (flags | 128) : (flags &~ 128);
             flags = hidden_prehistory ? (flags | 1024) : (flags &~ 1024);
-            flags = can_set_location ? (flags | 65536) : (flags &~ 65536);
+            flags = can_set_location ? (flags | 65536) : (flags & ~65536);
             flags = has_scheduled ? (flags | 524288) : (flags & ~524288);
             flags = can_view_stats ? (flags | 1048576) : (flags & ~1048576);
             flags = blocked ? (flags | 4194304) : (flags & ~4194304);
@@ -14091,7 +16142,8 @@ public class TLRPC {
             unread_count = stream.readInt32(exception);
             chat_photo = Photo.TLdeserialize(stream, stream.readInt32(exception), exception);
             notify_settings = PeerNotifySettings.TLdeserialize(stream, stream.readInt32(exception), exception);
-            ExportedChatInvite invite = ExportedChatInvite.TLdeserialize(stream, stream.readInt32(exception), exception);
+            ExportedChatInvite invite = ExportedChatInvite.TLdeserialize(stream, stream.readInt32(exception),
+                    exception);
             if (invite instanceof TL_chatInviteExported) {
                 exported_invite = (TL_chatInviteExported) invite;
             }
@@ -14139,11 +16191,11 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = can_view_participants ? (flags | 8) : (flags &~ 8);
-            flags = can_set_username ? (flags | 64) : (flags &~ 64);
-            flags = can_set_stickers ? (flags | 128) : (flags &~ 128);
-            flags = hidden_prehistory ? (flags | 1024) : (flags &~ 1024);
-            flags = can_view_stats ? (flags | 4096) : (flags &~ 4096);
+            flags = can_view_participants ? (flags | 8) : (flags & ~8);
+            flags = can_set_username ? (flags | 64) : (flags & ~64);
+            flags = can_set_stickers ? (flags | 128) : (flags & ~128);
+            flags = hidden_prehistory ? (flags | 1024) : (flags & ~1024);
+            flags = can_view_stats ? (flags | 4096) : (flags & ~4096);
             flags = can_set_location ? (flags | 65536) : (flags & ~65536);
             stream.writeInt32(flags);
             stream.writeInt32((int) id);
@@ -14206,6 +16258,7 @@ public class TLRPC {
     public static class TL_channelFull_layer101 extends TL_channelFull {
         public static int constructor = 0x9882e516;
 
+
         public void readParams(AbstractSerializedData stream, boolean exception) {
             flags = stream.readInt32(exception);
             can_view_participants = (flags & 8) != 0;
@@ -14235,8 +16288,7 @@ public class TLRPC {
             unread_count = stream.readInt32(exception);
             chat_photo = Photo.TLdeserialize(stream, stream.readInt32(exception), exception);
             notify_settings = PeerNotifySettings.TLdeserialize(stream, stream.readInt32(exception), exception);
-            ExportedChatInvite invite = ExportedChatInvite.TLdeserialize(stream, stream.readInt32(exception),
-                    exception);
+            ExportedChatInvite invite = ExportedChatInvite.TLdeserialize(stream, stream.readInt32(exception), exception);
             if (invite instanceof TL_chatInviteExported) {
                 exported_invite = (TL_chatInviteExported) invite;
             }
@@ -14281,11 +16333,11 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = can_view_participants ? (flags | 8) : (flags & ~8);
-            flags = can_set_username ? (flags | 64) : (flags & ~64);
-            flags = can_set_stickers ? (flags | 128) : (flags & ~128);
-            flags = hidden_prehistory ? (flags | 1024) : (flags & ~1024);
-            flags = can_view_stats ? (flags | 4096) : (flags & ~4096);
+            flags = can_view_participants ? (flags | 8) : (flags &~ 8);
+            flags = can_set_username ? (flags | 64) : (flags &~ 64);
+            flags = can_set_stickers ? (flags | 128) : (flags &~ 128);
+            flags = hidden_prehistory ? (flags | 1024) : (flags &~ 1024);
+            flags = can_view_stats ? (flags | 4096) : (flags &~ 4096);
             stream.writeInt32(flags);
             stream.writeInt32((int) id);
             stream.writeString(about);
@@ -14548,7 +16600,7 @@ public class TLRPC {
             flags = can_set_username ? (flags | 64) : (flags &~ 64);
             flags = can_set_stickers ? (flags | 128) : (flags &~ 128);
             flags = hidden_prehistory ? (flags | 1024) : (flags &~ 1024);
-            flags = can_view_stats ? (flags | 4096) : (flags &~ 4096);
+            flags = can_view_stats ? (flags | 4096) : (flags & ~4096);
             stream.writeInt32(flags);
             stream.writeInt32((int) id);
             stream.writeString(about);
@@ -14606,7 +16658,8 @@ public class TLRPC {
             participants = ChatParticipants.TLdeserialize(stream, stream.readInt32(exception), exception);
             chat_photo = Photo.TLdeserialize(stream, stream.readInt32(exception), exception);
             notify_settings = PeerNotifySettings.TLdeserialize(stream, stream.readInt32(exception), exception);
-            ExportedChatInvite invite = ExportedChatInvite.TLdeserialize(stream, stream.readInt32(exception), exception);
+            ExportedChatInvite invite = ExportedChatInvite.TLdeserialize(stream, stream.readInt32(exception),
+                    exception);
             if (invite instanceof TL_chatInviteExported) {
                 exported_invite = (TL_chatInviteExported) invite;
             }
@@ -14672,7 +16725,8 @@ public class TLRPC {
             unread_count = stream.readInt32(exception);
             chat_photo = Photo.TLdeserialize(stream, stream.readInt32(exception), exception);
             notify_settings = PeerNotifySettings.TLdeserialize(stream, stream.readInt32(exception), exception);
-            ExportedChatInvite invite = ExportedChatInvite.TLdeserialize(stream, stream.readInt32(exception), exception);
+            ExportedChatInvite invite = ExportedChatInvite.TLdeserialize(stream, stream.readInt32(exception),
+                    exception);
             if (invite instanceof TL_chatInviteExported) {
                 exported_invite = (TL_chatInviteExported) invite;
             }
@@ -14713,10 +16767,10 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = can_view_participants ? (flags | 8) : (flags &~ 8);
-            flags = can_set_username ? (flags | 64) : (flags &~ 64);
-            flags = can_set_stickers ? (flags | 128) : (flags &~ 128);
-            flags = hidden_prehistory ? (flags | 1024) : (flags &~ 1024);
+            flags = can_view_participants ? (flags | 8) : (flags & ~8);
+            flags = can_set_username ? (flags | 64) : (flags & ~64);
+            flags = can_set_stickers ? (flags | 128) : (flags & ~128);
+            flags = hidden_prehistory ? (flags | 1024) : (flags & ~1024);
             stream.writeInt32(flags);
             stream.writeInt32((int) id);
             stream.writeString(about);
@@ -15831,14 +17885,17 @@ public class TLRPC {
     }
 
     public static class TL_codeSettings extends TLObject {
-        public static int constructor = 0x8a6469c2;
+        public static int constructor = 0xad253d78;
 
         public int flags;
         public boolean allow_flashcall;
         public boolean current_number;
         public boolean allow_app_hash;
         public boolean allow_missed_call;
+        public boolean allow_firebase;
         public ArrayList<byte[]> logout_tokens = new ArrayList<>();
+        public String token;
+        public boolean app_sandbox;
 
         public static TL_codeSettings TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             if (TL_codeSettings.constructor != constructor) {
@@ -15859,6 +17916,7 @@ public class TLRPC {
             current_number = (flags & 2) != 0;
             allow_app_hash = (flags & 16) != 0;
             allow_missed_call = (flags & 32) != 0;
+            allow_firebase = (flags & 128) != 0;
             if ((flags & 64) != 0) {
                 int magic = stream.readInt32(exception);
                 if (magic != 0x1cb5c415) {
@@ -15869,9 +17927,17 @@ public class TLRPC {
                 }
                 int count = stream.readInt32(exception);
                 for (int a = 0; a < count; a++) {
-                    logout_tokens.add(stream.readByteArray(exception));
+                    byte[] object = stream.readByteArray(exception);
+                    if (object == null) {
+                        return;
+                    }
+                    logout_tokens.add(object);
                 }
             }
+            if ((flags & 256) != 0) {
+                token = stream.readString(exception);
+            }
+            app_sandbox = (flags & 256) != 0;
         }
 
         public void serializeToStream(AbstractSerializedData stream) {
@@ -15880,6 +17946,8 @@ public class TLRPC {
             flags = current_number ? (flags | 2) : (flags &~ 2);
             flags = allow_app_hash ? (flags | 16) : (flags &~ 16);
             flags = allow_missed_call ? (flags | 32) : (flags &~ 32);
+            flags = allow_firebase ? (flags | 128) : (flags & ~128);
+            flags = app_sandbox ? (flags | 256) : (flags & ~256);
             stream.writeInt32(flags);
             if ((flags & 64) != 0) {
                 stream.writeInt32(0x1cb5c415);
@@ -15889,6 +17957,78 @@ public class TLRPC {
                     stream.writeByteArray(logout_tokens.get(a));
                 }
             }
+            if ((flags & 256) != 0) {
+                stream.writeString(token);
+            }
+        }
+    }
+
+    public static abstract class account_EmojiStatuses extends TLObject {
+
+        public long hash;
+        public ArrayList<EmojiStatus> statuses = new ArrayList<>();
+
+        public static account_EmojiStatuses TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
+            account_EmojiStatuses result = null;
+            switch (constructor) {
+                case 0xd08ce645:
+                    result = new TL_account_emojiStatusesNotModified();
+                    break;
+                case 0x90c467d1:
+                    result = new TL_account_emojiStatuses();
+                    break;
+            }
+            if (result == null && exception) {
+                throw new RuntimeException(String.format("can't parse magic %x in account_EmojiStatuses", constructor));
+            }
+            if (result != null) {
+                result.readParams(stream, exception);
+            }
+            return result;
+        }
+    }
+
+    public static class TL_account_emojiStatusesNotModified extends account_EmojiStatuses {
+        public static int constructor = 0xd08ce645;
+
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
+    public static class TL_account_emojiStatuses extends account_EmojiStatuses {
+        public static int constructor = 0x90c467d1;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            hash = stream.readInt64(exception);
+            int magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            int count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                EmojiStatus object = EmojiStatus.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                statuses.add(object);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt64(hash);
+            stream.writeInt32(0x1cb5c415);
+            int count = statuses.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                statuses.get(a).serializeToStream(stream);
+            }
         }
     }
 
@@ -15897,10 +18037,12 @@ public class TLRPC {
 
         public StatsGraph views_graph;
 
-        public static TL_stats_messageStats TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+        public static TL_stats_messageStats TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
             if (TL_stats_messageStats.constructor != constructor) {
                 if (exception) {
-                    throw new RuntimeException(String.format("can't parse magic %x in TL_stats_messageStats", constructor));
+                    throw new RuntimeException(
+                            String.format("can't parse magic %x in TL_stats_messageStats", constructor));
                 } else {
                     return null;
                 }
@@ -16741,6 +18883,9 @@ public class TLRPC {
                 case 0x13767230:
                     result = new TL_keyboardButtonWebView();
                     break;
+                case 0xd0b468c:
+                    result = new TL_keyboardButtonRequestPeer();
+                    break;
             }
             if (result == null && exception) {
                 throw new RuntimeException(String.format("can't parse magic %x in KeyboardButton", constructor));
@@ -17000,6 +19145,73 @@ public class TLRPC {
         }
     }
 
+    public static class TL_videoSizeEmojiMarkup extends VideoSize {
+        public static int constructor = 0xf85c413c;
+
+        public long emoji_id;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            emoji_id = stream.readInt64(exception);
+            int magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            int count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                background_colors.add(stream.readInt32(exception));
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt64(emoji_id);
+            stream.writeInt32(0x1cb5c415);
+            int count = background_colors.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                stream.writeInt32(background_colors.get(a));
+            }
+        }
+    }
+
+    public static class TL_videoSizeStickerMarkup extends VideoSize {
+        public static int constructor = 0xda082fe;
+
+        public InputStickerSet stickerset;
+        public long sticker_id;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            stickerset = InputStickerSet.TLdeserialize(stream, stream.readInt32(exception), exception);
+            sticker_id = stream.readInt64(exception);
+            int magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            int count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                background_colors.add(stream.readInt32(exception));
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stickerset.serializeToStream(stream);
+            stream.writeInt64(sticker_id);
+            stream.writeInt32(0x1cb5c415);
+            int count = background_colors.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                stream.writeInt32(background_colors.get(a));
+            }
+        }
+    }
+
     public static abstract class VideoSize extends TLObject {
 
         public int flags;
@@ -17009,6 +19221,7 @@ public class TLRPC {
         public int h;
         public int size;
         public double video_start_ts;
+        public ArrayList<Integer> background_colors = new ArrayList<>();
 
         public static VideoSize TLdeserialize(long photo_id, long document_id, AbstractSerializedData stream, int constructor, boolean exception) {
             VideoSize result = null;
@@ -17021,6 +19234,12 @@ public class TLRPC {
                     break;
                 case 0xde33b094:
                     result = new TL_videoSize();
+                    break;
+                case 0xda082fe:
+                    result = new TL_videoSizeStickerMarkup();
+                    break;
+                case 0xf85c413c:
+                    result = new TL_videoSizeEmojiMarkup();
                     break;
             }
             if (result == null && exception) {
@@ -18537,7 +20756,7 @@ public class TLRPC {
         public static messages_FeaturedStickers TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             messages_FeaturedStickers result = null;
             switch (constructor) {
-                case 0x84c02310:
+                case 0xbe382906:
                     result = new TL_messages_featuredStickers();
                     break;
                 case 0xc6dc0c66:
@@ -18555,14 +20774,18 @@ public class TLRPC {
     }
 
     public static class TL_messages_featuredStickers extends messages_FeaturedStickers {
-        public static int constructor = 0x84c02310;
+        public static int constructor = 0xbe382906;
 
+        public int flags;
+        public boolean premium;
         public long hash;
         public int count;
         public ArrayList<StickerSetCovered> sets = new ArrayList<>();
         public ArrayList<Long> unread = new ArrayList<>();
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            premium = (flags & 1) != 0;
             hash = stream.readInt64(exception);
             count = stream.readInt32(exception);
             int magic = stream.readInt32(exception);
@@ -18595,6 +20818,8 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+            flags = premium ? (flags | 1) : (flags & ~1);
+            stream.writeInt32(flags);
             stream.writeInt64(hash);
             stream.writeInt32(count);
             stream.writeInt32(0x1cb5c415);
@@ -19078,8 +21303,7 @@ public class TLRPC {
         }
     }
 
-    public static class TL_dialogFilter extends TLObject {
-        public static int constructor = 0x7438f7e8;
+    public static abstract class DialogFilter extends TLObject {
 
         public int flags;
         public boolean contacts;
@@ -19097,18 +21321,37 @@ public class TLRPC {
         public ArrayList<InputPeer> include_peers = new ArrayList<>();
         public ArrayList<InputPeer> exclude_peers = new ArrayList<>();
 
-        public static TL_dialogFilter TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
-            if (TL_dialogFilter.constructor != constructor) {
-                if (exception) {
-                    throw new RuntimeException(String.format("can't parse magic %x in TL_dialogFilter", constructor));
-                } else {
-                    return null;
-                }
+        public static DialogFilter TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+            DialogFilter result = null;
+            switch (constructor) {
+                case 0x363293ae:
+                    result = new TL_dialogFilterDefault();
+                    break;
+                case 0x7438f7e8:
+                    result = new TL_dialogFilter();
+                    break;
             }
-            TL_dialogFilter result = new TL_dialogFilter();
-            result.readParams(stream, exception);
+            if (result == null && exception) {
+                throw new RuntimeException(String.format("can't parse magic %x in DialogFilter", constructor));
+            }
+            if (result != null) {
+                result.readParams(stream, exception);
+            }
             return result;
         }
+    }
+
+    public static class TL_dialogFilterDefault extends DialogFilter {
+        public static int constructor = 0x363293ae;
+
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
+    public static class TL_dialogFilter extends DialogFilter {
+        public static int constructor = 0x7438f7e8;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             flags = stream.readInt32(exception);
@@ -19183,7 +21426,7 @@ public class TLRPC {
             flags = exclude_read ? (flags | 4096) : (flags &~ 4096);
             flags = exclude_archived ? (flags | 8192) : (flags &~ 8192);
             stream.writeInt32(flags);
-            stream.writeInt32((int) id);
+            stream.writeInt32(id);
             stream.writeString(title);
             if ((flags & 33554432) != 0) {
                 stream.writeString(emoticon);
@@ -19237,6 +21480,39 @@ public class TLRPC {
         }
     }
 
+    public static class TL_exportedContactToken extends TLObject {
+        public static int constructor = 0x41bf109b;
+
+        public String url;
+        public int expires;
+
+        public static TL_exportedContactToken TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
+            if (TL_exportedContactToken.constructor != constructor) {
+                if (exception) {
+                    throw new RuntimeException(
+                            String.format("can't parse magic %x in TL_exportedContactToken", constructor));
+                } else {
+                    return null;
+                }
+            }
+            TL_exportedContactToken result = new TL_exportedContactToken();
+            result.readParams(stream, exception);
+            return result;
+        }
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            url = stream.readString(exception);
+            expires = stream.readInt32(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeString(url);
+            stream.writeInt32(expires);
+        }
+    }
+
     public static class TL_botCommand extends TLObject {
         public static int constructor = 0xc27ac8c7;
 
@@ -19284,6 +21560,9 @@ public class TLRPC {
                     break;
                 case 0xb1db7c7e:
                     result = new TL_inputNotifyBroadcasts();
+                    break;
+                case 0x5c467992:
+                    result = new TL_inputNotifyForumTopic();
                     break;
             }
             if (result == null && exception) {
@@ -19335,6 +21614,24 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+        }
+    }
+
+    public static class TL_inputNotifyForumTopic extends InputNotifyPeer {
+        public static int constructor = 0x5c467992;
+
+        public InputPeer peer;
+        public int top_msg_id;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            peer = InputPeer.TLdeserialize(stream, stream.readInt32(exception), exception);
+            top_msg_id = stream.readInt32(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            peer.serializeToStream(stream);
+            stream.writeInt32(top_msg_id);
         }
     }
 
@@ -19487,7 +21784,6 @@ public class TLRPC {
     public static class TL_inputGroupCallStream extends InputFileLocation {
         public static int constructor = 0x598a92a;
 
-        public int flags;
         public TL_inputGroupCall call;
         public long time_ms;
         public int scale;
@@ -20161,6 +22457,7 @@ public class TLRPC {
         public UserProfilePhoto photo;
         public UserStatus status;
         public int flags;
+        public int flags2;
         public boolean self;
         public boolean contact;
         public boolean mutual_contact;
@@ -20176,6 +22473,7 @@ public class TLRPC {
         public boolean scam;
         public boolean apply_min_photo;
         public boolean fake;
+        public boolean premium;
         public int bot_info_version;
         public String bot_inline_placeholder;
         public String lang_code;
@@ -20184,6 +22482,9 @@ public class TLRPC {
         public ArrayList<TL_restrictionReason> restriction_reason = new ArrayList<>();
         public boolean bot_attach_menu;
         public boolean bot_menu_webview;
+        public boolean attach_menu_enabled;
+        public EmojiStatus emoji_status;
+        public ArrayList<TL_username> usernames = new ArrayList<>();
 
         public static User TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             User result = null;
@@ -20197,8 +22498,14 @@ public class TLRPC {
                 case 0xd3bc4b7a:
                     result = new TL_userEmpty();
                     break;
-                case 0x3ff6ecb0:
+                case 0x8f97c628:
                     result = new TL_user();
+                    break;
+                case 0x5d99adee:
+                    result = new TL_user_layer147();
+                    break;
+                case 0x3ff6ecb0:
+                    result = new TL_user_layer144();
                     break;
                 case 0x938458c1:
                     result = new TL_user_layer131();
@@ -20322,8 +22629,7 @@ public class TLRPC {
     }
 
     public static class TL_user extends User {
-        public static int constructor = 0x3ff6ecb0;
-
+        public static int constructor = 0x8f97c628;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             flags = stream.readInt32(exception);
@@ -20343,7 +22649,9 @@ public class TLRPC {
             apply_min_photo = (flags & 33554432) != 0;
             fake = (flags & 67108864) != 0;
             bot_attach_menu = (flags & 134217728) != 0;
-            bot_menu_webview = (flags & 268435456) != 0;
+            premium = (flags & 268435456) != 0;
+            attach_menu_enabled = (flags & 536870912) != 0;
+            flags2 = stream.readInt32(exception);
             id = stream.readInt64(exception);
             if ((flags & 1) != 0) {
                 access_hash = stream.readInt64(exception);
@@ -20392,6 +22700,180 @@ public class TLRPC {
             if ((flags & 4194304) != 0) {
                 lang_code = stream.readString(exception);
             }
+            if ((flags & 1073741824) != 0) {
+                emoji_status = EmojiStatus.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags2 & 1) != 0) {
+                int magic = stream.readInt32(exception);
+                if (magic != 0x1cb5c415) {
+                    if (exception) {
+                        throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                    }
+                    return;
+                }
+                int count = stream.readInt32(exception);
+                for (int a = 0; a < count; a++) {
+                    TL_username object = TL_username.TLdeserialize(stream, stream.readInt32(exception), exception);
+                    if (object == null) {
+                        return;
+                    }
+                    usernames.add(object);
+                }
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            if (username == null) {
+                flags = flags & ~8;
+            }
+            stream.writeInt32(constructor);
+            flags = self ? (flags | 1024) : (flags &~ 1024);
+            flags = contact ? (flags | 2048) : (flags &~ 2048);
+            flags = mutual_contact ? (flags | 4096) : (flags &~ 4096);
+            flags = deleted ? (flags | 8192) : (flags &~ 8192);
+            flags = bot ? (flags | 16384) : (flags &~ 16384);
+            flags = bot_chat_history ? (flags | 32768) : (flags &~ 32768);
+            flags = bot_nochats ? (flags | 65536) : (flags &~ 65536);
+            flags = verified ? (flags | 131072) : (flags &~ 131072);
+            flags = restricted ? (flags | 262144) : (flags &~ 262144);
+            flags = min ? (flags | 1048576) : (flags &~ 1048576);
+            flags = bot_inline_geo ? (flags | 2097152) : (flags &~ 2097152);
+            flags = support ? (flags | 8388608) : (flags &~ 8388608);
+            flags = scam ? (flags | 16777216) : (flags &~ 16777216);
+            flags = apply_min_photo ? (flags | 33554432) : (flags &~ 33554432);
+            flags = fake ? (flags | 67108864) : (flags &~ 67108864);
+            flags = bot_attach_menu ? (flags | 134217728) : (flags & ~134217728);
+            flags = premium ? (flags | 268435456) : (flags & ~268435456);
+            flags = attach_menu_enabled ? (flags | 536870912) : (flags & ~536870912);
+            stream.writeInt32(flags);
+            stream.writeInt32(flags2);
+            stream.writeInt64(id);
+            if ((flags & 1) != 0) {
+                stream.writeInt64(access_hash);
+            }
+            if ((flags & 2) != 0) {
+                stream.writeString(first_name);
+            }
+            if ((flags & 4) != 0) {
+                stream.writeString(last_name);
+            }
+            if ((flags & 8) != 0) {
+                stream.writeString(username);
+            }
+            if ((flags & 16) != 0) {
+                stream.writeString(phone);
+            }
+            if ((flags & 32) != 0) {
+                photo.serializeToStream(stream);
+            }
+            if ((flags & 64) != 0) {
+                status.serializeToStream(stream);
+            }
+            if ((flags & 16384) != 0) {
+                stream.writeInt32(bot_info_version);
+            }
+            if ((flags & 262144) != 0) {
+                stream.writeInt32(0x1cb5c415);
+                int count = restriction_reason.size();
+                stream.writeInt32(count);
+                for (int a = 0; a < count; a++) {
+                    restriction_reason.get(a).serializeToStream(stream);
+                }
+            }
+            if ((flags & 524288) != 0) {
+                stream.writeString(bot_inline_placeholder);
+            }
+            if ((flags & 4194304) != 0) {
+                stream.writeString(lang_code);
+            }
+            if ((flags & 1073741824) != 0) {
+                emoji_status.serializeToStream(stream);
+            }
+            if ((flags2 & 1) != 0) {
+                stream.writeInt32(0x1cb5c415);
+                int count = usernames.size();
+                stream.writeInt32(count);
+                for (int a = 0; a < count; a++) {
+                    usernames.get(a).serializeToStream(stream);
+                }
+            }
+        }
+    }
+
+    public static class TL_user_layer147 extends User {
+        public static int constructor = 0x5d99adee;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            self = (flags & 1024) != 0;
+            contact = (flags & 2048) != 0;
+            mutual_contact = (flags & 4096) != 0;
+            deleted = (flags & 8192) != 0;
+            bot = (flags & 16384) != 0;
+            bot_chat_history = (flags & 32768) != 0;
+            bot_nochats = (flags & 65536) != 0;
+            verified = (flags & 131072) != 0;
+            restricted = (flags & 262144) != 0;
+            min = (flags & 1048576) != 0;
+            bot_inline_geo = (flags & 2097152) != 0;
+            support = (flags & 8388608) != 0;
+            scam = (flags & 16777216) != 0;
+            apply_min_photo = (flags & 33554432) != 0;
+            fake = (flags & 67108864) != 0;
+            bot_attach_menu = (flags & 134217728) != 0;
+            premium = (flags & 268435456) != 0;
+            attach_menu_enabled = (flags & 536870912) != 0;
+            id = stream.readInt64(exception);
+            if ((flags & 1) != 0) {
+                access_hash = stream.readInt64(exception);
+            }
+            if ((flags & 2) != 0) {
+                first_name = stream.readString(exception);
+            }
+            if ((flags & 4) != 0) {
+                last_name = stream.readString(exception);
+            }
+            if ((flags & 8) != 0) {
+                username = stream.readString(exception);
+            }
+            if ((flags & 16) != 0) {
+                phone = stream.readString(exception);
+            }
+            if ((flags & 32) != 0) {
+                photo = UserProfilePhoto.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 64) != 0) {
+                status = UserStatus.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 16384) != 0) {
+                bot_info_version = stream.readInt32(exception);
+            }
+            if ((flags & 262144) != 0) {
+                int magic = stream.readInt32(exception);
+                if (magic != 0x1cb5c415) {
+                    if (exception) {
+                        throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                    }
+                    return;
+                }
+                int count = stream.readInt32(exception);
+                for (int a = 0; a < count; a++) {
+                    TL_restrictionReason object = TL_restrictionReason.TLdeserialize(stream, stream.readInt32(exception), exception);
+                    if (object == null) {
+                        return;
+                    }
+                    restriction_reason.add(object);
+                }
+            }
+            if ((flags & 524288) != 0) {
+                bot_inline_placeholder = stream.readString(exception);
+            }
+            if ((flags & 4194304) != 0) {
+                lang_code = stream.readString(exception);
+            }
+            if ((flags & 1073741824) != 0) {
+                emoji_status = EmojiStatus.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
         }
 
         public void serializeToStream(AbstractSerializedData stream) {
@@ -20412,7 +22894,146 @@ public class TLRPC {
             flags = apply_min_photo ? (flags | 33554432) : (flags &~ 33554432);
             flags = fake ? (flags | 67108864) : (flags &~ 67108864);
             flags = bot_attach_menu ? (flags | 134217728) : (flags & ~134217728);
-            flags = bot_menu_webview ? (flags | 268435456) : (flags & ~268435456);
+            flags = premium ? (flags | 268435456) : (flags & ~268435456);
+            flags = attach_menu_enabled ? (flags | 536870912) : (flags & ~536870912);
+            stream.writeInt32(flags);
+            stream.writeInt64(id);
+            if ((flags & 1) != 0) {
+                stream.writeInt64(access_hash);
+            }
+            if ((flags & 2) != 0) {
+                stream.writeString(first_name);
+            }
+            if ((flags & 4) != 0) {
+                stream.writeString(last_name);
+            }
+            if ((flags & 8) != 0) {
+                stream.writeString(username);
+            }
+            if ((flags & 16) != 0) {
+                stream.writeString(phone);
+            }
+            if ((flags & 32) != 0) {
+                photo.serializeToStream(stream);
+            }
+            if ((flags & 64) != 0) {
+                status.serializeToStream(stream);
+            }
+            if ((flags & 16384) != 0) {
+                stream.writeInt32(bot_info_version);
+            }
+            if ((flags & 262144) != 0) {
+                stream.writeInt32(0x1cb5c415);
+                int count = restriction_reason.size();
+                stream.writeInt32(count);
+                for (int a = 0; a < count; a++) {
+                    restriction_reason.get(a).serializeToStream(stream);
+                }
+            }
+            if ((flags & 524288) != 0) {
+                stream.writeString(bot_inline_placeholder);
+            }
+            if ((flags & 4194304) != 0) {
+                stream.writeString(lang_code);
+            }
+            if ((flags & 1073741824) != 0) {
+                emoji_status.serializeToStream(stream);
+            }
+        }
+    }
+
+    public static class TL_user_layer144 extends User {
+        public static int constructor = 0x3ff6ecb0;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            self = (flags & 1024) != 0;
+            contact = (flags & 2048) != 0;
+            mutual_contact = (flags & 4096) != 0;
+            deleted = (flags & 8192) != 0;
+            bot = (flags & 16384) != 0;
+            bot_chat_history = (flags & 32768) != 0;
+            bot_nochats = (flags & 65536) != 0;
+            verified = (flags & 131072) != 0;
+            restricted = (flags & 262144) != 0;
+            min = (flags & 1048576) != 0;
+            bot_inline_geo = (flags & 2097152) != 0;
+            support = (flags & 8388608) != 0;
+            scam = (flags & 16777216) != 0;
+            apply_min_photo = (flags & 33554432) != 0;
+            fake = (flags & 67108864) != 0;
+            bot_attach_menu = (flags & 134217728) != 0;
+            premium = (flags & 268435456) != 0;
+            id = stream.readInt64(exception);
+            if ((flags & 1) != 0) {
+                access_hash = stream.readInt64(exception);
+            }
+            if ((flags & 2) != 0) {
+                first_name = stream.readString(exception);
+            }
+            if ((flags & 4) != 0) {
+                last_name = stream.readString(exception);
+            }
+            if ((flags & 8) != 0) {
+                username = stream.readString(exception);
+            }
+            if ((flags & 16) != 0) {
+                phone = stream.readString(exception);
+            }
+            if ((flags & 32) != 0) {
+                photo = UserProfilePhoto.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 64) != 0) {
+                status = UserStatus.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 16384) != 0) {
+                bot_info_version = stream.readInt32(exception);
+            }
+            if ((flags & 262144) != 0) {
+                int magic = stream.readInt32(exception);
+                if (magic != 0x1cb5c415) {
+                    if (exception) {
+                        throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                    }
+                    return;
+                }
+                int count = stream.readInt32(exception);
+                for (int a = 0; a < count; a++) {
+                    TL_restrictionReason object = TL_restrictionReason.TLdeserialize(stream,
+                            stream.readInt32(exception), exception);
+                    if (object == null) {
+                        return;
+                    }
+                    restriction_reason.add(object);
+                }
+            }
+            if ((flags & 524288) != 0) {
+                bot_inline_placeholder = stream.readString(exception);
+            }
+            if ((flags & 4194304) != 0) {
+                lang_code = stream.readString(exception);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = self ? (flags | 1024) : (flags &~ 1024);
+            flags = contact ? (flags | 2048) : (flags &~ 2048);
+            flags = mutual_contact ? (flags | 4096) : (flags &~ 4096);
+            flags = deleted ? (flags | 8192) : (flags &~ 8192);
+            flags = bot ? (flags | 16384) : (flags &~ 16384);
+            flags = bot_chat_history ? (flags | 32768) : (flags &~ 32768);
+            flags = bot_nochats ? (flags | 65536) : (flags &~ 65536);
+            flags = verified ? (flags | 131072) : (flags &~ 131072);
+            flags = restricted ? (flags | 262144) : (flags &~ 262144);
+            flags = min ? (flags | 1048576) : (flags &~ 1048576);
+            flags = bot_inline_geo ? (flags | 2097152) : (flags &~ 2097152);
+            flags = support ? (flags | 8388608) : (flags &~ 8388608);
+            flags = scam ? (flags | 16777216) : (flags &~ 16777216);
+            flags = apply_min_photo ? (flags | 33554432) : (flags & ~33554432);
+            flags = fake ? (flags | 67108864) : (flags & ~67108864);
+            flags = bot_attach_menu ? (flags | 134217728) : (flags & ~134217728);
+            flags = premium ? (flags | 268435456) : (flags & ~268435456);
             stream.writeInt32(flags);
             stream.writeInt64(id);
             if ((flags & 1) != 0) {
@@ -20512,7 +23133,8 @@ public class TLRPC {
                 }
                 int count = stream.readInt32(exception);
                 for (int a = 0; a < count; a++) {
-                    TL_restrictionReason object = TL_restrictionReason.TLdeserialize(stream, stream.readInt32(exception), exception);
+                    TL_restrictionReason object = TL_restrictionReason.TLdeserialize(stream,
+                            stream.readInt32(exception), exception);
                     if (object == null) {
                         return;
                     }
@@ -20529,21 +23151,21 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = self ? (flags | 1024) : (flags &~ 1024);
-            flags = contact ? (flags | 2048) : (flags &~ 2048);
-            flags = mutual_contact ? (flags | 4096) : (flags &~ 4096);
-            flags = deleted ? (flags | 8192) : (flags &~ 8192);
-            flags = bot ? (flags | 16384) : (flags &~ 16384);
-            flags = bot_chat_history ? (flags | 32768) : (flags &~ 32768);
-            flags = bot_nochats ? (flags | 65536) : (flags &~ 65536);
-            flags = verified ? (flags | 131072) : (flags &~ 131072);
-            flags = restricted ? (flags | 262144) : (flags &~ 262144);
-            flags = min ? (flags | 1048576) : (flags &~ 1048576);
-            flags = bot_inline_geo ? (flags | 2097152) : (flags &~ 2097152);
-            flags = support ? (flags | 8388608) : (flags &~ 8388608);
-            flags = scam ? (flags | 16777216) : (flags &~ 16777216);
-            flags = apply_min_photo ? (flags | 33554432) : (flags &~ 33554432);
-            flags = fake ? (flags | 67108864) : (flags &~ 67108864);
+            flags = self ? (flags | 1024) : (flags & ~1024);
+            flags = contact ? (flags | 2048) : (flags & ~2048);
+            flags = mutual_contact ? (flags | 4096) : (flags & ~4096);
+            flags = deleted ? (flags | 8192) : (flags & ~8192);
+            flags = bot ? (flags | 16384) : (flags & ~16384);
+            flags = bot_chat_history ? (flags | 32768) : (flags & ~32768);
+            flags = bot_nochats ? (flags | 65536) : (flags & ~65536);
+            flags = verified ? (flags | 131072) : (flags & ~131072);
+            flags = restricted ? (flags | 262144) : (flags & ~262144);
+            flags = min ? (flags | 1048576) : (flags & ~1048576);
+            flags = bot_inline_geo ? (flags | 2097152) : (flags & ~2097152);
+            flags = support ? (flags | 8388608) : (flags & ~8388608);
+            flags = scam ? (flags | 16777216) : (flags & ~16777216);
+            flags = apply_min_photo ? (flags | 33554432) : (flags & ~33554432);
+            flags = fake ? (flags | 67108864) : (flags & ~67108864);
             stream.writeInt32(flags);
             stream.writeInt32((int) id);
             if ((flags & 1) != 0) {
@@ -20644,19 +23266,19 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = self ? (flags | 1024) : (flags &~ 1024);
-            flags = contact ? (flags | 2048) : (flags &~ 2048);
-            flags = mutual_contact ? (flags | 4096) : (flags &~ 4096);
-            flags = deleted ? (flags | 8192) : (flags &~ 8192);
-            flags = bot ? (flags | 16384) : (flags &~ 16384);
-            flags = bot_chat_history ? (flags | 32768) : (flags &~ 32768);
-            flags = bot_nochats ? (flags | 65536) : (flags &~ 65536);
-            flags = verified ? (flags | 131072) : (flags &~ 131072);
-            flags = restricted ? (flags | 262144) : (flags &~ 262144);
-            flags = min ? (flags | 1048576) : (flags &~ 1048576);
-            flags = bot_inline_geo ? (flags | 2097152) : (flags &~ 2097152);
-            flags = support ? (flags | 8388608) : (flags &~ 8388608);
-            flags = scam ? (flags | 16777216) : (flags &~ 16777216);
+            flags = self ? (flags | 1024) : (flags & ~1024);
+            flags = contact ? (flags | 2048) : (flags & ~2048);
+            flags = mutual_contact ? (flags | 4096) : (flags & ~4096);
+            flags = deleted ? (flags | 8192) : (flags & ~8192);
+            flags = bot ? (flags | 16384) : (flags & ~16384);
+            flags = bot_chat_history ? (flags | 32768) : (flags & ~32768);
+            flags = bot_nochats ? (flags | 65536) : (flags & ~65536);
+            flags = verified ? (flags | 131072) : (flags & ~131072);
+            flags = restricted ? (flags | 262144) : (flags & ~262144);
+            flags = min ? (flags | 1048576) : (flags & ~1048576);
+            flags = bot_inline_geo ? (flags | 2097152) : (flags & ~2097152);
+            flags = support ? (flags | 8388608) : (flags & ~8388608);
+            flags = scam ? (flags | 16777216) : (flags & ~16777216);
             stream.writeInt32(flags);
             stream.writeInt32((int) id);
             if ((flags & 1) != 0) {
@@ -21664,11 +24286,16 @@ public class TLRPC {
         public long call_id;
         public PhoneCallDiscardReason reason;
         public int duration;
+        public boolean recurring_init;
+        public boolean recurring_used;
         public String currency;
+        public long amount;
         public long total_amount;
+        public String invoice_slug;
         public long game_id;
         public int score;
         public boolean video;
+        public int months;
 
         public static MessageAction TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             MessageAction result = null;
@@ -21745,6 +24372,12 @@ public class TLRPC {
                 case 0x55555550:
                     result = new TL_messageActionUserJoined();
                     break;
+                case 0xb18a431c:
+                    result = new TL_messageActionTopicEdit_layer149();
+                    break;
+                case 0xc0944820:
+                    result = new TL_messageActionTopicEdit();
+                    break;
                 case 0x55555551:
                     result = new TL_messageActionUserUpdatedPhoto();
                     break;
@@ -21754,8 +24387,11 @@ public class TLRPC {
                 case 0x55555552:
                     result = new TL_messageActionTTLChange();
                     break;
-                case 0xaa1afbfd:
+                case 0x3c134d7b:
                     result = new TL_messageActionSetMessagesTTL();
+                    break;
+                case 0xaa1afbfd:
+                    result = new TL_messageActionSetMessagesTTL_layer149();
                     break;
                 case 0xd95c6154:
                     result = new TL_messageActionSecureValuesSent();
@@ -21781,6 +24417,12 @@ public class TLRPC {
                 case 0x98e0d697:
                     result = new TL_messageActionGeoProximityReached();
                     break;
+                case 0x57de635e:
+                    result = new TL_messageActionSuggestProfilePhoto();
+                    break;
+                case 0xe7e75f97:
+                    result = new TL_messageActionAttachMenuBotAllowed();
+                    break;
                 case 0x95e3fbef:
                     result = new TL_messageActionChatDeletePhoto();
                     break;
@@ -21790,14 +24432,20 @@ public class TLRPC {
                 case 0x80e11a7f:
                     result = new TL_messageActionPhoneCall();
                     break;
+                case 0xd999256:
+                    result = new TL_messageActionTopicCreate();
+                    break;
                 case 0xb5a1ce5a:
                     result = new TL_messageActionChatEditTitle();
                     break;
                 case 0xabe9affe:
                     result = new TL_messageActionBotAllowed();
                     break;
-                case 0x40699cd0:
+                case 0x96163f56:
                     result = new TL_messageActionPaymentSent();
+                    break;
+                case 0x40699cd0:
+                    result = new TL_messageActionPaymentSent_layer140();
                     break;
                 case 0xb6aef7b0:
                     result = new TL_messageActionEmpty();
@@ -21807,6 +24455,15 @@ public class TLRPC {
                     break;
                 case 0xb3a07661:
                     result = new TL_messageActionGroupCallScheduled();
+                    break;
+                case 0x8f31b327:
+                    result = new TL_messageActionPaymentSentMe();
+                    break;
+                case 0xaba0f5c6:
+                    result = new TL_messageActionGiftPremium();
+                    break;
+                case 0xfe77345d:
+                    result = new TL_messageActionRequestedPeer();
                     break;
             }
             if (result == null && exception) {
@@ -22009,6 +24666,28 @@ public class TLRPC {
         }
     }
 
+    public static class TL_messages_getExtendedMedia extends TLObject {
+        public static int constructor = 0x84f80814;
+
+        public InputPeer peer;
+        public ArrayList<Integer> id = new ArrayList<>();
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Updates.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            peer.serializeToStream(stream);
+            stream.writeInt32(0x1cb5c415);
+            int count = id.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                stream.writeInt32(id.get(a));
+            }
+        }
+    }
+
     public static class TL_messages_getMessageReadParticipants extends TLObject {
         public static int constructor = 0x2c6f97b7;
 
@@ -22126,6 +24805,78 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+        }
+    }
+
+    public static class TL_messageActionTopicEdit extends MessageAction {
+        public static int constructor = 0xc0944820;
+
+        public long icon_emoji_id;
+        public boolean closed;
+        public boolean hidden;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            if ((flags & 1) != 0) {
+                title = stream.readString(exception);
+            }
+            if ((flags & 2) != 0) {
+                icon_emoji_id = stream.readInt64(exception);
+            }
+            if ((flags & 4) != 0) {
+                closed = stream.readBool(exception);
+            }
+            if ((flags & 8) != 0) {
+                hidden = stream.readBool(exception);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(flags);
+            if ((flags & 1) != 0) {
+                stream.writeString(title);
+            }
+            if ((flags & 2) != 0) {
+                stream.writeInt64(icon_emoji_id);
+            }
+            if ((flags & 4) != 0) {
+                stream.writeBool(closed);
+            }
+            if ((flags & 8) != 0) {
+                stream.writeBool(hidden);
+            }
+        }
+    }
+
+    public static class TL_messageActionTopicEdit_layer149 extends TL_messageActionTopicEdit {
+        public static int constructor = 0xb18a431c;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            if ((flags & 1) != 0) {
+                title = stream.readString(exception);
+            }
+            if ((flags & 2) != 0) {
+                icon_emoji_id = stream.readInt64(exception);
+            }
+            if ((flags & 4) != 0) {
+                closed = stream.readBool(exception);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(flags);
+            if ((flags & 1) != 0) {
+                stream.writeString(title);
+            }
+            if ((flags & 2) != 0) {
+                stream.writeInt64(icon_emoji_id);
+            }
+            if ((flags & 4) != 0) {
+                stream.writeBool(closed);
+            }
         }
     }
 
@@ -22359,9 +25110,31 @@ public class TLRPC {
     }
 
     public static class TL_messageActionSetMessagesTTL extends MessageAction {
-        public static int constructor = 0xaa1afbfd;
+        public static int constructor = 0x3c134d7b;
 
         public int period;
+        public long auto_setting_from;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            period = stream.readInt32(exception);
+            if ((flags & 1) != 0) {
+                auto_setting_from = stream.readInt64(exception);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(flags);
+            stream.writeInt32(period);
+            if ((flags & 1) != 0) {
+                stream.writeInt64(auto_setting_from);
+            }
+        }
+    }
+
+    public static class TL_messageActionSetMessagesTTL_layer149 extends TL_messageActionSetMessagesTTL {
+        public static int constructor = 0xaa1afbfd;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             period = stream.readInt32(exception);
@@ -22504,6 +25277,32 @@ public class TLRPC {
         }
     }
 
+    public static class TL_messageActionTopicCreate extends MessageAction {
+        public static int constructor = 0xd999256;
+
+        public int icon_color;
+        public long icon_emoji_id;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            title = stream.readString(exception);
+            icon_color = stream.readInt32(exception);
+            if ((flags & 1) != 0) {
+                icon_emoji_id = stream.readInt64(exception);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(flags);
+            stream.writeString(title);
+            stream.writeInt32(icon_color);
+            if ((flags & 1) != 0) {
+                stream.writeInt64(icon_emoji_id);
+            }
+        }
+    }
+
     public static class TL_messageActionChatEditTitle extends MessageAction {
         public static int constructor = 0xb5a1ce5a;
 
@@ -22519,8 +25318,34 @@ public class TLRPC {
     }
 
     public static class TL_messageActionPaymentSent extends MessageAction {
-        public static int constructor = 0x40699cd0;
+        public static int constructor = 0x96163f56;
 
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            recurring_init = (flags & 4) != 0;
+            recurring_used = (flags & 8) != 0;
+            currency = stream.readString(exception);
+            total_amount = stream.readInt64(exception);
+            if ((flags & 1) != 0) {
+                invoice_slug = stream.readString(exception);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = recurring_init ? (flags | 4) : (flags & ~4);
+            flags = recurring_used ? (flags | 8) : (flags & ~8);
+            stream.writeInt32(flags);
+            stream.writeString(currency);
+            stream.writeInt64(total_amount);
+            if ((flags & 1) != 0) {
+                stream.writeString(invoice_slug);
+            }
+        }
+    }
+
+    public static class TL_messageActionPaymentSent_layer140 extends TL_messageActionPaymentSent {
+        public static int constructor = 0x40699cd0;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             currency = stream.readString(exception);
@@ -22571,6 +25396,63 @@ public class TLRPC {
             stream.writeInt32(constructor);
             stream.writeInt64(game_id);
             stream.writeInt32(score);
+        }
+    }
+
+    public static class TL_messageActionGiftPremium extends MessageAction {
+        public static int constructor = 0xaba0f5c6;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            currency = stream.readString(exception);
+            amount = stream.readInt64(exception);
+            months = stream.readInt32(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeString(currency);
+            stream.writeInt64(amount);
+            stream.writeInt32(months);
+        }
+    }
+
+    public static class TL_messageActionPaymentSentMe extends MessageAction {
+        public static int constructor = 0x8f31b327;
+
+        public int flags;
+        public byte[] payload;
+        public TL_paymentRequestedInfo info;
+        public String shipping_option_id;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            recurring_init = (flags & 4) != 0;
+            recurring_used = (flags & 8) != 0;
+            currency = stream.readString(exception);
+            total_amount = stream.readInt64(exception);
+            payload = stream.readByteArray(exception);
+            if ((flags & 1) != 0) {
+                info = TL_paymentRequestedInfo.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 2) != 0) {
+                shipping_option_id = stream.readString(exception);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = recurring_init ? (flags | 4) : (flags & ~4);
+            flags = recurring_used ? (flags | 8) : (flags & ~8);
+            stream.writeInt32(flags);
+            stream.writeString(currency);
+            stream.writeInt64(total_amount);
+            stream.writeByteArray(payload);
+            if ((flags & 1) != 0) {
+                info.serializeToStream(stream);
+            }
+            if ((flags & 2) != 0) {
+                stream.writeString(shipping_option_id);
+            }
         }
     }
 
@@ -22714,6 +25596,7 @@ public class TLRPC {
 
     public static class TL_inputReportReasonPersonalDetails extends ReportReason {
         public static int constructor = 0x9ec7863d;
+
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
@@ -22902,7 +25785,8 @@ public class TLRPC {
             ttl = stream.readInt32(exception);
             message = stream.readString(exception);
             if ((flags & 512) != 0) {
-                media = DecryptedMessageMedia.TLdeserialize(stream, stream.readInt32(exception), exception);
+                media = DecryptedMessageMedia.TLdeserialize(stream, stream.readInt32(exception),
+                        exception || BuildVars.DEBUG_PRIVATE_VERSION);
             }
             if ((flags & 128) != 0) {
                 int magic = stream.readInt32(exception);
@@ -22914,7 +25798,8 @@ public class TLRPC {
                 }
                 int count = stream.readInt32(exception);
                 for (int a = 0; a < count; a++) {
-                    MessageEntity object = MessageEntity.TLdeserialize(stream, stream.readInt32(exception), exception);
+                    MessageEntity object = MessageEntity.TLdeserialize(stream, stream.readInt32(exception),
+                            exception || BuildVars.DEBUG_PRIVATE_VERSION);
                     if (object == null) {
                         return;
                     }
@@ -23094,7 +25979,7 @@ public class TLRPC {
     }
 
     public static class TL_invoice extends TLObject {
-        public static int constructor = 0xcd886e0;
+        public static int constructor = 0x3e85a91b;
 
         public int flags;
         public boolean test;
@@ -23105,10 +25990,12 @@ public class TLRPC {
         public boolean flexible;
         public boolean phone_to_provider;
         public boolean email_to_provider;
+        public boolean recurring;
         public String currency;
         public ArrayList<TL_labeledPrice> prices = new ArrayList<>();
         public long max_tip_amount;
         public ArrayList<Long> suggested_tip_amounts = new ArrayList<>();
+        public String recurring_terms_url;
 
         public static TL_invoice TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             if (TL_invoice.constructor != constructor) {
@@ -23133,6 +26020,7 @@ public class TLRPC {
             flexible = (flags & 32) != 0;
             phone_to_provider = (flags & 64) != 0;
             email_to_provider = (flags & 128) != 0;
+            recurring = (flags & 512) != 0;
             currency = stream.readString(exception);
             int magic = stream.readInt32(exception);
             if (magic != 0x1cb5c415) {
@@ -23165,6 +26053,9 @@ public class TLRPC {
                     suggested_tip_amounts.add(stream.readInt64(exception));
                 }
             }
+            if ((flags & 512) != 0) {
+                recurring_terms_url = stream.readString(exception);
+            }
         }
 
         public void serializeToStream(AbstractSerializedData stream) {
@@ -23177,6 +26068,7 @@ public class TLRPC {
             flags = flexible ? (flags | 32) : (flags &~ 32);
             flags = phone_to_provider ? (flags | 64) : (flags &~ 64);
             flags = email_to_provider ? (flags | 128) : (flags &~ 128);
+            flags = recurring ? (flags | 512) : (flags & ~512);
             stream.writeInt32(flags);
             stream.writeString(currency);
             stream.writeInt32(0x1cb5c415);
@@ -23195,6 +26087,9 @@ public class TLRPC {
                 for (int a = 0; a < count; a++) {
                     stream.writeInt64(suggested_tip_amounts.get(a));
                 }
+            }
+            if ((flags & 512) != 0) {
+                stream.writeString(recurring_terms_url);
             }
         }
     }
@@ -23328,8 +26223,8 @@ public class TLRPC {
         public int flags;
         public boolean min;
         public boolean can_see_list;
-        public ArrayList<TL_reactionCount> results = new ArrayList<>();
-        public ArrayList<TL_messagePeerReaction> recent_reactions = new ArrayList<>();
+        public ArrayList<ReactionCount> results = new ArrayList<>();
+        public ArrayList<MessagePeerReaction> recent_reactions = new ArrayList<>();
 
         public static TL_messageReactions TLdeserialize(AbstractSerializedData stream, int constructor,
                 boolean exception) {
@@ -23371,8 +26266,7 @@ public class TLRPC {
             }
             int count = stream.readInt32(exception);
             for (int a = 0; a < count; a++) {
-                TL_reactionCount object = TL_reactionCount.TLdeserialize(stream, stream.readInt32(exception),
-                        exception);
+                ReactionCount object = ReactionCount.TLdeserialize(stream, stream.readInt32(exception), exception);
                 if (object == null) {
                     return;
                 }
@@ -23388,8 +26282,8 @@ public class TLRPC {
                 }
                 count = stream.readInt32(exception);
                 for (int a = 0; a < count; a++) {
-                    TL_messagePeerReaction object = MessagePeerReaction.TLdeserialize(stream,
-                            stream.readInt32(exception), exception);
+                    MessagePeerReaction object = MessagePeerReaction.TLdeserialize(stream, stream.readInt32(exception),
+                            exception);
                     if (object == null) {
                         return;
                     }
@@ -23423,6 +26317,7 @@ public class TLRPC {
     public static class TL_messageReactionsOld extends TL_messageReactions {
         public static int constructor = 0x87b6e36;
 
+
         public static TL_messageReactions TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             if (TL_messageReactions.constructor != constructor) {
                 if (exception) {
@@ -23449,7 +26344,7 @@ public class TLRPC {
             }
             int count = stream.readInt32(exception);
             for (int a = 0; a < count; a++) {
-                TL_reactionCount object = TL_reactionCount.TLdeserialize(stream, stream.readInt32(exception), exception);
+                ReactionCount object = ReactionCount.TLdeserialize(stream, stream.readInt32(exception), exception);
                 if (object == null) {
                     return;
                 }
@@ -23465,8 +26360,8 @@ public class TLRPC {
                 }
                 count = stream.readInt32(exception);
                 for (int a = 0; a < count; a++) {
-                    TL_messagePeerReaction object = TL_messagePeerReaction.TLdeserialize(stream,
-                            stream.readInt32(exception), exception);
+                    MessagePeerReaction object = MessagePeerReaction.TLdeserialize(stream, stream.readInt32(exception),
+                            exception);
                     if (object == null) {
                         return;
                     }
@@ -23512,8 +26407,7 @@ public class TLRPC {
             }
             int count = stream.readInt32(exception);
             for (int a = 0; a < count; a++) {
-                TL_reactionCount object = TL_reactionCount.TLdeserialize(stream, stream.readInt32(exception),
-                        exception);
+                ReactionCount object = ReactionCount.TLdeserialize(stream, stream.readInt32(exception), exception);
                 if (object == null) {
                     return;
                 }
@@ -24058,10 +26952,12 @@ public class TLRPC {
         public static int constructor = 0xa6d57763;
 
         public int flags;
+        public boolean reply_to_scheduled;
+        public boolean forum_topic;
         public int reply_to_msg_id;
         public Peer reply_to_peer_id;
         public int reply_to_top_id;
-        public long reply_to_random_id;
+        public long reply_to_random_id; // custom
 
         public static TL_messageReplyHeader TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             if (TL_messageReplyHeader.constructor != constructor) {
@@ -24078,6 +26974,8 @@ public class TLRPC {
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             flags = stream.readInt32(exception);
+            reply_to_scheduled = (flags & 4) != 0;
+            forum_topic = (flags & 8) != 0;
             reply_to_msg_id = stream.readInt32(exception);
             if ((flags & 1) != 0) {
                 reply_to_peer_id = Peer.TLdeserialize(stream, stream.readInt32(exception), exception);
@@ -24089,6 +26987,8 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+            flags = reply_to_scheduled ? (flags | 4) : (flags & ~4);
+            flags = forum_topic ? (flags | 8) : (flags & ~8);
             stream.writeInt32(flags);
             stream.writeInt32(reply_to_msg_id);
             if ((flags & 1) != 0) {
@@ -24736,7 +27636,7 @@ public class TLRPC {
         public int date;
         public String file_name;
         public String mime_type;
-        public int size;
+        public long size;
         public ArrayList<PhotoSize> thumbs = new ArrayList<>();
         public ArrayList<VideoSize> video_thumbs = new ArrayList<>();
         public int version;
@@ -24745,6 +27645,7 @@ public class TLRPC {
         public byte[] iv;
         public ArrayList<DocumentAttribute> attributes = new ArrayList<>();
         public String file_name_fixed; // custom
+        public String localPath; // custom
 
         public static Document TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             Document result = null;
@@ -24761,8 +27662,11 @@ public class TLRPC {
                 case 0x55555556:
                     result = new TL_documentEncrypted_old();
                     break;
-                case 0x1e87342b:
+                case 0x8fd4c4d8:
                     result = new TL_document();
+                    break;
+                case 0x1e87342b:
+                    result = new TL_document_layer142();
                     break;
                 case 0x9efc6326:
                     result = new TL_document_old();
@@ -24782,7 +27686,7 @@ public class TLRPC {
             }
             if (result != null) {
                 result.readParams(stream, exception);
-                result.file_name_fixed = Utilities.getDocumentFileName(result);
+                result.file_name_fixed = FileLoader.getDocumentFileName(result);
             }
             return result;
         }
@@ -24825,7 +27729,7 @@ public class TLRPC {
             stream.writeByteArray(file_reference);
             stream.writeInt32(date);
             stream.writeString(mime_type);
-            stream.writeInt32(size);
+            stream.writeInt32((int) size);
             thumbs.get(0).serializeToStream(stream);
             stream.writeInt32(dc_id);
             stream.writeInt32(0x1cb5c415);
@@ -24873,7 +27777,7 @@ public class TLRPC {
             stream.writeInt64(access_hash);
             stream.writeInt32(date);
             stream.writeString(mime_type);
-            stream.writeInt32(size);
+            stream.writeInt32((int) size);
             thumbs.get(0).serializeToStream(stream);
             stream.writeInt32(dc_id);
             stream.writeInt32(0);
@@ -24912,7 +27816,7 @@ public class TLRPC {
             stream.writeInt32(date);
             stream.writeString(file_name);
             stream.writeString(mime_type);
-            stream.writeInt32(size);
+            stream.writeInt32((int) size);
             thumbs.get(0).serializeToStream(stream);
             stream.writeInt32(dc_id);
             stream.writeByteArray(key);
@@ -24921,6 +27825,106 @@ public class TLRPC {
     }
 
     public static class TL_document extends Document {
+        public static int constructor = 0x8fd4c4d8;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            id = stream.readInt64(exception);
+            access_hash = stream.readInt64(exception);
+            file_reference = stream.readByteArray(exception);
+            date = stream.readInt32(exception);
+            mime_type = stream.readString(exception);
+            size = stream.readInt64(exception);
+            if ((flags & 1) != 0) {
+                int magic = stream.readInt32(exception);
+                if (magic != 0x1cb5c415) {
+                    if (exception) {
+                        throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                    }
+                    return;
+                }
+                int count = stream.readInt32(exception);
+                for (int a = 0; a < count; a++) {
+                    PhotoSize object = PhotoSize.TLdeserialize(0, id, 0, stream, stream.readInt32(exception),
+                            exception);
+                    if (object == null) {
+                        return;
+                    }
+                    thumbs.add(object);
+                }
+            }
+            if ((flags & 2) != 0) {
+                int magic = stream.readInt32(exception);
+                if (magic != 0x1cb5c415) {
+                    if (exception) {
+                        throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                    }
+                    return;
+                }
+                int count = stream.readInt32(exception);
+                for (int a = 0; a < count; a++) {
+                    VideoSize object = VideoSize.TLdeserialize(0, id, stream, stream.readInt32(exception), exception);
+                    if (object == null) {
+                        return;
+                    }
+                    video_thumbs.add(object);
+                }
+            }
+            dc_id = stream.readInt32(exception);
+            int magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            int count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                DocumentAttribute object = DocumentAttribute.TLdeserialize(stream, stream.readInt32(exception),
+                        exception);
+                if (object == null) {
+                    return;
+                }
+                attributes.add(object);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(flags);
+            stream.writeInt64(id);
+            stream.writeInt64(access_hash);
+            stream.writeByteArray(file_reference);
+            stream.writeInt32(date);
+            stream.writeString(mime_type);
+            stream.writeInt64(size);
+            if ((flags & 1) != 0) {
+                stream.writeInt32(0x1cb5c415);
+                int count = thumbs.size();
+                stream.writeInt32(count);
+                for (int a = 0; a < count; a++) {
+                    thumbs.get(a).serializeToStream(stream);
+                }
+            }
+            if ((flags & 2) != 0) {
+                stream.writeInt32(0x1cb5c415);
+                int count = video_thumbs.size();
+                stream.writeInt32(count);
+                for (int a = 0; a < count; a++) {
+                    video_thumbs.get(a).serializeToStream(stream);
+                }
+            }
+            stream.writeInt32(dc_id);
+            stream.writeInt32(0x1cb5c415);
+            int count = attributes.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                attributes.get(a).serializeToStream(stream);
+            }
+        }
+    }
+
+    public static class TL_document_layer142 extends TL_document {
         public static int constructor = 0x1e87342b;
 
 
@@ -24992,7 +27996,7 @@ public class TLRPC {
             stream.writeByteArray(file_reference);
             stream.writeInt32(date);
             stream.writeString(mime_type);
-            stream.writeInt32(size);
+            stream.writeInt32((int) size);
             if ((flags & 1) != 0) {
                 stream.writeInt32(0x1cb5c415);
                 int count = thumbs.size();
@@ -25074,7 +28078,7 @@ public class TLRPC {
             stream.writeByteArray(file_reference);
             stream.writeInt32(date);
             stream.writeString(mime_type);
-            stream.writeInt32(size);
+            stream.writeInt32((int) size);
             if ((flags & 1) != 0) {
                 stream.writeInt32(0x1cb5c415);
                 int count = thumbs.size();
@@ -25117,7 +28121,7 @@ public class TLRPC {
             stream.writeInt32(date);
             stream.writeString(file_name);
             stream.writeString(mime_type);
-            stream.writeInt32(size);
+            stream.writeInt32((int) size);
             thumbs.get(0).serializeToStream(stream);
             stream.writeInt32(dc_id);
         }
@@ -25174,7 +28178,7 @@ public class TLRPC {
             stream.writeInt64(access_hash);
             stream.writeInt32(date);
             stream.writeString(mime_type);
-            stream.writeInt32(size);
+            stream.writeInt32((int) size);
             thumbs.get(0).serializeToStream(stream);
             stream.writeInt32(dc_id);
             stream.writeInt32(0x1cb5c415);
@@ -25223,7 +28227,7 @@ public class TLRPC {
             stream.writeInt64(access_hash);
             stream.writeInt32(date);
             stream.writeString(mime_type);
-            stream.writeInt32(size);
+            stream.writeInt32((int) size);
             thumbs.get(0).serializeToStream(stream);
             stream.writeInt32(dc_id);
             stream.writeInt32(0x1cb5c415);
@@ -26582,6 +29586,7 @@ public class TLRPC {
         public String mime_type;
         public ArrayList<DocumentAttribute> attributes = new ArrayList<>();
         public int proximity_notification_radius;
+        public boolean spoiler;
 
         public static InputMedia TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             InputMedia result = null;
@@ -26666,6 +29671,7 @@ public class TLRPC {
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             flags = stream.readInt32(exception);
+            spoiler = (flags & 4) != 0;
             id = InputDocument.TLdeserialize(stream, stream.readInt32(exception), exception);
             if ((flags & 1) != 0) {
                 ttl_seconds = stream.readInt32(exception);
@@ -26677,6 +29683,7 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+            flags = spoiler ? (flags | 4) : (flags & ~4);
             stream.writeInt32(flags);
             id.serializeToStream(stream);
             if ((flags & 1) != 0) {
@@ -26739,6 +29746,7 @@ public class TLRPC {
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             flags = stream.readInt32(exception);
+            spoiler = (flags & 2) != 0;
             url = stream.readString(exception);
             if ((flags & 1) != 0) {
                 ttl_seconds = stream.readInt32(exception);
@@ -26747,6 +29755,7 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+            flags = spoiler ? (flags | 2) : (flags & ~2);
             stream.writeInt32(flags);
             stream.writeString(url);
             if ((flags & 1) != 0) {
@@ -26842,6 +29851,7 @@ public class TLRPC {
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             flags = stream.readInt32(exception);
+            spoiler = (flags & 4) != 0;
             file = InputFile.TLdeserialize(stream, stream.readInt32(exception), exception);
             if ((flags & 1) != 0) {
                 int magic = stream.readInt32(exception);
@@ -26867,6 +29877,7 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+            flags = spoiler ? (flags | 4) : (flags & ~4);
             stream.writeInt32(flags);
             file.serializeToStream(stream);
             if ((flags & 1) != 0) {
@@ -26951,6 +29962,7 @@ public class TLRPC {
             flags = stream.readInt32(exception);
             nosound_video = (flags & 8) != 0;
             force_file = (flags & 16) != 0;
+            spoiler = (flags & 32) != 0;
             file = InputFile.TLdeserialize(stream, stream.readInt32(exception), exception);
             if ((flags & 4) != 0) {
                 thumb = InputFile.TLdeserialize(stream, stream.readInt32(exception), exception);
@@ -26997,6 +30009,7 @@ public class TLRPC {
             stream.writeInt32(constructor);
             flags = nosound_video ? (flags | 8) : (flags &~ 8);
             flags = force_file ? (flags | 16) : (flags &~ 16);
+            flags = spoiler ? (flags | 32) : (flags & ~32);
             stream.writeInt32(flags);
             file.serializeToStream(stream);
             if ((flags & 4) != 0) {
@@ -27030,6 +30043,7 @@ public class TLRPC {
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             flags = stream.readInt32(exception);
+            spoiler = (flags & 2) != 0;
             url = stream.readString(exception);
             if ((flags & 1) != 0) {
                 ttl_seconds = stream.readInt32(exception);
@@ -27038,6 +30052,7 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+            flags = spoiler ? (flags | 2) : (flags & ~2);
             stream.writeInt32(flags);
             stream.writeString(url);
             if ((flags & 1) != 0) {
@@ -27053,6 +30068,7 @@ public class TLRPC {
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             flags = stream.readInt32(exception);
+            spoiler = (flags & 2) != 0;
             id = InputPhoto.TLdeserialize(stream, stream.readInt32(exception), exception);
             if ((flags & 1) != 0) {
                 ttl_seconds = stream.readInt32(exception);
@@ -27061,6 +30077,7 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+            flags = spoiler ? (flags | 2) : (flags & ~2);
             stream.writeInt32(flags);
             id.serializeToStream(stream);
             if ((flags & 1) != 0) {
@@ -27079,6 +30096,15 @@ public class TLRPC {
             switch (constructor) {
                 case 0x3407e51b:
                     result = new TL_stickerSetMultiCovered();
+                    break;
+                case 0x1aed5ee5:
+                    result = new TL_stickerSetFullCovered_layer146();
+                    break;
+                case 0x40d13c0e:
+                    result = new TL_stickerSetFullCovered();
+                    break;
+                case 0x77b15d1c:
+                    result = new TL_stickerSetNoCovered();
                     break;
                 case 0x6410a5d2:
                     result = new TL_stickerSetCovered();
@@ -27129,6 +30155,202 @@ public class TLRPC {
         }
     }
 
+    public static class TL_stickerKeyword extends TLObject {
+        public static int constructor = 0xfcfeb29c;
+
+        public long document_id;
+        public ArrayList<String> keyword = new ArrayList<>();
+
+        public static TL_stickerKeyword TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
+            if (TL_stickerKeyword.constructor != constructor) {
+                if (exception) {
+                    throw new RuntimeException(String.format("can't parse magic %x in TL_stickerKeyword", constructor));
+                } else {
+                    return null;
+                }
+            }
+            TL_stickerKeyword result = new TL_stickerKeyword();
+            result.readParams(stream, exception);
+            return result;
+        }
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            document_id = stream.readInt64(exception);
+            int magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            int count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                keyword.add(stream.readString(exception));
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt64(document_id);
+            stream.writeInt32(0x1cb5c415);
+            int count = keyword.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                stream.writeString(keyword.get(a));
+            }
+        }
+    }
+
+    public static class TL_stickerSetFullCovered_layer146 extends TL_stickerSetFullCovered {
+        public static int constructor = 0x1aed5ee5;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            set = StickerSet.TLdeserialize(stream, stream.readInt32(exception), exception);
+            int magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            int count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                TL_stickerPack object = TL_stickerPack.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                packs.add(object);
+            }
+            magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                Document object = Document.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                documents.add(object);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            set.serializeToStream(stream);
+            stream.writeInt32(0x1cb5c415);
+            int count = packs.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                packs.get(a).serializeToStream(stream);
+            }
+            stream.writeInt32(0x1cb5c415);
+            count = documents.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                documents.get(a).serializeToStream(stream);
+            }
+        }
+    }
+
+    public static class TL_stickerSetNoCovered extends StickerSetCovered {
+        public static int constructor = 0x77b15d1c;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            set = StickerSet.TLdeserialize(stream, stream.readInt32(exception), exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            set.serializeToStream(stream);
+        }
+    }
+
+    public static class TL_stickerSetFullCovered extends StickerSetCovered {
+        public static int constructor = 0x40d13c0e;
+
+        public ArrayList<TL_stickerPack> packs = new ArrayList<>();
+        public ArrayList<TL_stickerKeyword> keywords = new ArrayList<>();
+        public ArrayList<Document> documents = new ArrayList<>();
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            set = StickerSet.TLdeserialize(stream, stream.readInt32(exception), exception);
+            int magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            int count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                TL_stickerPack object = TL_stickerPack.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                packs.add(object);
+            }
+            magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                TL_stickerKeyword object = TL_stickerKeyword.TLdeserialize(stream, stream.readInt32(exception),
+                        exception);
+                if (object == null) {
+                    return;
+                }
+                keywords.add(object);
+            }
+            magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                Document object = Document.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                documents.add(object);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            set.serializeToStream(stream);
+            stream.writeInt32(0x1cb5c415);
+            int count = packs.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                packs.get(a).serializeToStream(stream);
+            }
+            stream.writeInt32(0x1cb5c415);
+            count = keywords.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                keywords.get(a).serializeToStream(stream);
+            }
+            stream.writeInt32(0x1cb5c415);
+            count = documents.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                documents.get(a).serializeToStream(stream);
+            }
+        }
+    }
+
     public static class TL_stickerSetCovered extends StickerSetCovered {
         public static int constructor = 0x6410a5d2;
 
@@ -27152,7 +30374,8 @@ public class TLRPC {
         public byte[] bytes;
         public EncryptedFile file;
 
-        public static EncryptedMessage TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+        public static EncryptedMessage TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
             EncryptedMessage result = null;
             switch (constructor) {
                 case 0x23734b06:
@@ -27238,6 +30461,18 @@ public class TLRPC {
                 case 0xe67f520e:
                     result = new TL_inputStickerSetDice();
                     break;
+                case 0xc88b3b02:
+                    result = new TL_inputStickerSetPremiumGifts();
+                    break;
+                case 0x29d0f5ee:
+                    result = new TL_inputStickerSetEmojiDefaultStatuses();
+                    break;
+                case 0x4c4d4ce:
+                    result = new TL_inputStickerSetEmojiGenericAnimations();
+                    break;
+                case 0x44c1f8e9:
+                    result = new TL_inputStickerSetEmojiDefaultTopicIcons();
+                    break;
             }
             if (result == null && exception) {
                 throw new RuntimeException(String.format("can't parse magic %x in InputStickerSet", constructor));
@@ -27246,6 +30481,24 @@ public class TLRPC {
                 result.readParams(stream, exception);
             }
             return result;
+        }
+    }
+
+    public static class TL_inputStickerSetPremiumGifts extends InputStickerSet {
+        public static int constructor = 0xc88b3b02;
+
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
+    public static class TL_inputStickerSetEmojiDefaultStatuses extends InputStickerSet {
+        public static int constructor = 0x29d0f5ee;
+
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
         }
     }
 
@@ -27305,6 +30558,24 @@ public class TLRPC {
 
     public static class TL_inputStickerSetAnimatedEmoji extends InputStickerSet {
         public static int constructor = 0x28703c8;
+
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
+    public static class TL_inputStickerSetEmojiGenericAnimations extends InputStickerSet {
+        public static int constructor = 0x4c4d4ce;
+
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
+    public static class TL_inputStickerSetEmojiDefaultTopicIcons extends InputStickerSet {
+        public static int constructor = 0x44c1f8e9;
 
 
         public void serializeToStream(AbstractSerializedData stream) {
@@ -27827,7 +31098,7 @@ public class TLRPC {
     public static class TL_dialogFilterSuggested extends TLObject {
         public static int constructor = 0x77744d4a;
 
-        public TL_dialogFilter filter;
+        public DialogFilter filter;
         public String description;
 
         public static TL_dialogFilterSuggested TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
@@ -27844,7 +31115,7 @@ public class TLRPC {
         }
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
-            filter = TL_dialogFilter.TLdeserialize(stream, stream.readInt32(exception), exception);
+            filter = DialogFilter.TLdeserialize(stream, stream.readInt32(exception), exception);
             description = stream.readString(exception);
         }
 
@@ -27891,6 +31162,9 @@ public class TLRPC {
         public static Update TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             Update result = null;
             switch (constructor) {
+                case 0x5a73a98c:
+                    result = new TL_updateMessageExtendedMedia();
+                    break;
                 case 0xaca1657b:
                     result = new TL_updateMessagePoll();
                     break;
@@ -27945,7 +31219,7 @@ public class TLRPC {
                 case 0x8c88c923:
                     result = new TL_updateChannelUserTyping();
                     break;
-                case 0x43ae3dec:
+                case 0x31c24808:
                     result = new TL_updateStickerSets();
                     break;
                 case 0x19360dc0:
@@ -27960,8 +31234,14 @@ public class TLRPC {
                 case 0x12bcbd9a:
                     result = new TL_updateNewEncryptedMessage();
                     break;
+                case 0x86fccf85:
+                    result = new TL_updateMoveStickerSetToTop();
+                    break;
                 case 0xe5bdf8de:
                     result = new TL_updateUserStatus();
+                    break;
+                case 0x28373599:
+                    result = new TL_updateUserEmojiStatus();
                     break;
                 case 0xf226ac08:
                     result = new TL_updateChannelMessageViews();
@@ -27987,8 +31267,14 @@ public class TLRPC {
                 case 0xe32f3d77:
                     result = new TL_updateChatParticipantDelete();
                     break;
+                case 0xfb4c496c:
+                    result = new TL_updateReadFeaturedEmojiStickers();
+                    break;
                 case 0xe40370a3:
                     result = new TL_updateEditMessage();
+                    break;
+                case 0x6f7863f4:
+                    result = new TL_updateRecentReactions();
                     break;
                 case 0x7f891213:
                     result = new TL_updateWebPage();
@@ -28029,7 +31315,7 @@ public class TLRPC {
                 case 0xd7ca61a2:
                     result = new TL_updateChatParticipantAdmin();
                     break;
-                case 0x44bdd535:
+                case 0xea29055d:
                     result = new TL_updateChannelReadMessagesContents();
                     break;
                 case 0xee3b272a:
@@ -28041,13 +31327,13 @@ public class TLRPC {
                 case 0xe16459c3:
                     result = new TL_updateDialogUnreadMark();
                     break;
-                case 0xee2bb969:
+                case 0x1b49ec6d:
                     result = new TL_updateDraftMessage();
                     break;
-                case 0xc3f202e0:
+                case 0xa7848924:
                     result = new TL_updateUserName();
                     break;
-                case 0x154798c3:
+                case 0x5e1b3cb8:
                     result = new TL_updateMessageReactions();
                     break;
                 case 0xab0f6b1e:
@@ -28065,11 +31351,17 @@ public class TLRPC {
                 case 0x2661bf09:
                     result = new TL_updatePhoneCallSignalingData();
                     break;
+                case 0x88617090:
+                    result = new TL_updateTranscribeAudio();
+                    break;
                 case 0xfa0f3ca2:
                     result = new TL_updatePinnedDialogs();
                     break;
                 case 0x74d8be99:
                     result = new TL_updateSavedRingtones();
+                    break;
+                case 0x84cd5a:
+                    result = new TL_updateTranscribedAudio();
                     break;
                 case 0xb4afcfb0:
                     result = new TL_updatePeerLocated();
@@ -28107,11 +31399,17 @@ public class TLRPC {
                 case 0xf227868c:
                     result = new TL_updateUserPhoto();
                     break;
+                case 0x20529438:
+                    result = new TL_updateUser();
+                    break;
                 case 0x17b7a20b:
                     result = new TL_updateAttachMenuBots();
                     break;
                 case 0x3504914f:
                     result = new TL_updateDialogFilters();
+                    break;
+                case 0x30f443db:
+                    result = new TL_updateRecentEmojiStatuses();
                     break;
                 case 0x7063c3db:
                     result = new TL_updatePendingJoinRequests();
@@ -28152,6 +31450,12 @@ public class TLRPC {
                 case 0x14b85813:
                     result = new TL_updateBotMenuButton();
                     break;
+                case 0xfe198602:
+                    result = new TL_updateChannelPinnedTopics();
+                    break;
+                case 0x192efbe3:
+                    result = new TL_updateChannelPinnedTopic();
+                    break;
             }
             if (result == null && exception) {
                 throw new RuntimeException(String.format("can't parse magic %x in Update", constructor));
@@ -28160,6 +31464,51 @@ public class TLRPC {
                 result.readParams(stream, exception);
             }
             return result;
+        }
+    }
+
+    public static class TL_updateMoveStickerSetToTop extends Update {
+        public static int constructor = 0x86fccf85;
+
+        public int flags;
+        public boolean masks;
+        public boolean emojis;
+        public long stickerset;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            masks = (flags & 1) != 0;
+            emojis = (flags & 2) != 0;
+            stickerset = stream.readInt64(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = masks ? (flags | 1) : (flags & ~1);
+            flags = emojis ? (flags | 2) : (flags & ~2);
+            stream.writeInt32(flags);
+            stream.writeInt64(stickerset);
+        }
+    }
+
+    public static class TL_updateMessageExtendedMedia extends Update {
+        public static int constructor = 0x5a73a98c;
+
+        public Peer peer;
+        public int msg_id;
+        public MessageExtendedMedia extended_media;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            peer = Peer.TLdeserialize(stream, stream.readInt32(exception), exception);
+            msg_id = stream.readInt32(exception);
+            extended_media = MessageExtendedMedia.TLdeserialize(stream, stream.readInt32(exception), exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            peer.serializeToStream(stream);
+            stream.writeInt32(msg_id);
+            extended_media.serializeToStream(stream);
         }
     }
 
@@ -28591,11 +31940,23 @@ public class TLRPC {
     }
 
     public static class TL_updateStickerSets extends Update {
-        public static int constructor = 0x43ae3dec;
+        public static int constructor = 0x31c24808;
 
+        public int flags;
+        public boolean masks;
+        public boolean emojis;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            masks = (flags & 1) != 0;
+            emojis = (flags & 2) != 0;
+        }
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+            flags = masks ? (flags | 1) : (flags & ~1);
+            flags = emojis ? (flags | 2) : (flags & ~2);
+            stream.writeInt32(flags);
         }
     }
 
@@ -28943,6 +32304,14 @@ public class TLRPC {
         }
     }
 
+    public static class TL_updateRecentReactions extends Update {
+        public static int constructor = 0x6f7863f4;
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
     public static class TL_updateWebPage extends Update {
         public static int constructor = 0x7f891213;
 
@@ -29173,6 +32542,54 @@ public class TLRPC {
         }
     }
 
+    public static class TL_updateTranscribedAudio extends Update {
+        public static int constructor = 0x84cd5a;
+
+        public int flags;
+        public boolean pending;
+        public Peer peer;
+        public int msg_id;
+        public long transcription_id;
+        public String text;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            pending = (flags & 1) != 0;
+            peer = Peer.TLdeserialize(stream, stream.readInt32(exception), exception);
+            msg_id = stream.readInt32(exception);
+            transcription_id = stream.readInt64(exception);
+            text = stream.readString(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = pending ? (flags | 1) : (flags & ~1);
+            stream.writeInt32(flags);
+            peer.serializeToStream(stream);
+            stream.writeInt32(msg_id);
+            stream.writeInt64(transcription_id);
+            stream.writeString(text);
+        }
+    }
+
+    public static class TL_updateUserEmojiStatus extends Update {
+        public static int constructor = 0x28373599;
+
+        public long user_id;
+        public EmojiStatus emoji_status;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            user_id = stream.readInt64(exception);
+            emoji_status = EmojiStatus.TLdeserialize(stream, stream.readInt32(exception), exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt64(user_id);
+            emoji_status.serializeToStream(stream);
+        }
+    }
+
     public static class TL_updateLangPack extends Update {
         public static int constructor = 0x56022f4d;
 
@@ -29231,13 +32648,19 @@ public class TLRPC {
     }
 
     public static class TL_updateChannelReadMessagesContents extends Update {
-        public static int constructor = 0x44bdd535;
+        public static int constructor = 0xea29055d;
 
+        public int flags;
         public long channel_id;
+        public int top_msg_id;
         public ArrayList<Integer> messages = new ArrayList<>();
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
             channel_id = stream.readInt64(exception);
+            if ((flags & 1) != 0) {
+                top_msg_id = stream.readInt32(exception);
+            }
             int magic = stream.readInt32(exception);
             if (magic != 0x1cb5c415) {
                 if (exception) {
@@ -29253,7 +32676,11 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+            stream.writeInt32(flags);
             stream.writeInt64(channel_id);
+            if ((flags & 1) != 0) {
+                stream.writeInt32(top_msg_id);
+            }
             stream.writeInt32(0x1cb5c415);
             int count = messages.size();
             stream.writeInt32(count);
@@ -29331,36 +32758,60 @@ public class TLRPC {
     }
 
     public static class TL_updateDraftMessage extends Update {
-        public static int constructor = 0xee2bb969;
+        public static int constructor = 0x1b49ec6d;
 
+        public int flags;
         public Peer peer;
+        public int top_msg_id;
         public DraftMessage draft;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
             peer = Peer.TLdeserialize(stream, stream.readInt32(exception), exception);
+            if ((flags & 1) != 0) {
+                top_msg_id = stream.readInt32(exception);
+            }
             draft = DraftMessage.TLdeserialize(stream, stream.readInt32(exception), exception);
         }
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+            stream.writeInt32(flags);
             peer.serializeToStream(stream);
+            if ((flags & 1) != 0) {
+                stream.writeInt32(top_msg_id);
+            }
             draft.serializeToStream(stream);
         }
     }
 
     public static class TL_updateUserName extends Update {
-        public static int constructor = 0xc3f202e0;
+        public static int constructor = 0xa7848924;
 
         public long user_id;
         public String first_name;
         public String last_name;
-        public String username;
+        public ArrayList<TL_username> usernames = new ArrayList<>();
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             user_id = stream.readInt64(exception);
             first_name = stream.readString(exception);
             last_name = stream.readString(exception);
-            username = stream.readString(exception);
+            int magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            int count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                TL_username object = TL_username.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                usernames.add(object);
+            }
         }
 
         public void serializeToStream(AbstractSerializedData stream) {
@@ -29368,28 +32819,43 @@ public class TLRPC {
             stream.writeInt64(user_id);
             stream.writeString(first_name);
             stream.writeString(last_name);
-            stream.writeString(username);
+            stream.writeInt32(0x1cb5c415);
+            int count = usernames.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                usernames.get(a).serializeToStream(stream);
+            }
         }
     }
 
     public static class TL_updateMessageReactions extends Update {
-        public static int constructor = 0x154798c3;
+        public static int constructor = 0x5e1b3cb8;
 
+        public int flags;
         public Peer peer;
         public int msg_id;
+        public int top_msg_id;
         public TL_messageReactions reactions;
         public boolean updateUnreadState = true; // custom
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
             peer = Peer.TLdeserialize(stream, stream.readInt32(exception), exception);
             msg_id = stream.readInt32(exception);
-            reactions = TL_messageReactions.TLdeserialize(stream, stream.readInt32(exception), exception);
+            if ((flags & 1) != 0) {
+                top_msg_id = stream.readInt32(exception);
+            }
+            reactions = MessageReactions.TLdeserialize(stream, stream.readInt32(exception), exception);
         }
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+            stream.writeInt32(flags);
             peer.serializeToStream(stream);
             stream.writeInt32(msg_id);
+            if ((flags & 1) != 0) {
+                stream.writeInt32(top_msg_id);
+            }
             reactions.serializeToStream(stream);
         }
     }
@@ -29414,13 +32880,13 @@ public class TLRPC {
 
         public int flags;
         public int id;
-        public TL_dialogFilter filter;
+        public DialogFilter filter;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             flags = stream.readInt32(exception);
             id = stream.readInt32(exception);
             if ((flags & 1) != 0) {
-                filter = TL_dialogFilter.TLdeserialize(stream, stream.readInt32(exception), exception);
+                filter = DialogFilter.TLdeserialize(stream, stream.readInt32(exception), exception);
             }
         }
 
@@ -29512,6 +32978,30 @@ public class TLRPC {
             stream.writeInt32(constructor);
             stream.writeInt64(phone_call_id);
             stream.writeByteArray(data);
+        }
+    }
+
+    public static class TL_updateTranscribeAudio extends Update {
+        public static int constructor = 0x88617090;
+
+        public int flags;
+        public boolean isFinal;
+        public long transcription_id;
+        public String text;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            isFinal = (flags & 1) != 0;
+            transcription_id = stream.readInt64(exception);
+            text = stream.readString(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = isFinal ? (flags | 1) : (flags & ~1);
+            stream.writeInt32(flags);
+            stream.writeInt64(transcription_id);
+            stream.writeString(text);
         }
     }
 
@@ -29847,8 +33337,32 @@ public class TLRPC {
         }
     }
 
+    public static class TL_updateUser extends Update {
+        public static int constructor = 0x20529438;
+
+        public long user_id;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            user_id = stream.readInt64(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt64(user_id);
+        }
+    }
+
     public static class TL_updateDialogFilters extends Update {
         public static int constructor = 0x3504914f;
+
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
+    public static class TL_updateRecentEmojiStatuses extends Update {
+        public static int constructor = 0x30f443db;
 
 
         public void serializeToStream(AbstractSerializedData stream) {
@@ -30018,11 +33532,13 @@ public class TLRPC {
 
         public int flags;
         public boolean masks;
+        public boolean emojis;
         public ArrayList<Long> order = new ArrayList<>();
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             flags = stream.readInt32(exception);
             masks = (flags & 1) != 0;
+            emojis = (flags & 2) != 0;
             int magic = stream.readInt32(exception);
             if (magic != 0x1cb5c415) {
                 if (exception) {
@@ -30039,6 +33555,7 @@ public class TLRPC {
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
             flags = masks ? (flags | 1) : (flags &~ 1);
+            flags = emojis ? (flags | 2) : (flags & ~2);
             stream.writeInt32(flags);
             stream.writeInt32(0x1cb5c415);
             int count = order.size();
@@ -30046,6 +33563,15 @@ public class TLRPC {
             for (int a = 0; a < count; a++) {
                 stream.writeInt64(order.get(a));
             }
+        }
+    }
+
+    public static class TL_updateReadFeaturedEmojiStickers extends Update {
+        public static int constructor = 0xfb4c496c;
+
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
         }
     }
 
@@ -30152,6 +33678,70 @@ public class TLRPC {
             peer.serializeToStream(stream);
             default_banned_rights.serializeToStream(stream);
             stream.writeInt32(version);
+        }
+    }
+
+    public static class TL_updateChannelPinnedTopics extends Update {
+        public static int constructor = 0xfe198602;
+
+        public int flags;
+        public long channel_id;
+        public ArrayList<Integer> order = new ArrayList<>();
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            channel_id = stream.readInt64(exception);
+            if ((flags & 1) != 0) {
+                int magic = stream.readInt32(exception);
+                if (magic != 0x1cb5c415) {
+                    if (exception) {
+                        throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                    }
+                    return;
+                }
+                int count = stream.readInt32(exception);
+                for (int a = 0; a < count; a++) {
+                    order.add(stream.readInt32(exception));
+                }
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(flags);
+            stream.writeInt64(channel_id);
+            if ((flags & 1) != 0) {
+                stream.writeInt32(0x1cb5c415);
+                int count = order.size();
+                stream.writeInt32(count);
+                for (int a = 0; a < count; a++) {
+                    stream.writeInt32(order.get(a));
+                }
+            }
+        }
+    }
+
+    public static class TL_updateChannelPinnedTopic extends Update {
+        public static int constructor = 0x192efbe3;
+
+        public int flags;
+        public boolean pinned;
+        public long channel_id;
+        public int topic_id;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            pinned = (flags & 1) != 0;
+            channel_id = stream.readInt64(exception);
+            topic_id = stream.readInt32(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = pinned ? (flags | 1) : (flags & ~1);
+            stream.writeInt32(flags);
+            stream.writeInt64(channel_id);
+            stream.writeInt32(topic_id);
         }
     }
 
@@ -30311,10 +33901,10 @@ public class TLRPC {
     public static class TL_messages_allStickers extends messages_AllStickers {
         public static int constructor = 0xcdbbcebb;
 
-        public long hash;
+        public long hash2;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
-            hash = stream.readInt64(exception);
+            hash2 = stream.readInt64(exception);
             int magic = stream.readInt32(exception);
             if (magic != 0x1cb5c415) {
                 if (exception) {
@@ -30334,7 +33924,7 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            stream.writeInt64(hash);
+            stream.writeInt64(hash2);
             stream.writeInt32(0x1cb5c415);
             int count = sets.size();
             stream.writeInt32(count);
@@ -30788,8 +34378,7 @@ public class TLRPC {
         }
     }
 
-    public static class TL_account_password extends TLObject {
-        public static int constructor = 0x185b184f;
+    public static abstract class account_Password extends TLObject {
 
         public int flags;
         public boolean has_recovery;
@@ -30804,19 +34393,98 @@ public class TLRPC {
         public SecurePasswordKdfAlgo new_secure_algo;
         public byte[] secure_random;
         public int pending_reset_date;
+        public String login_email_pattern;
 
-        public static TL_account_password TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
-            if (TL_account_password.constructor != constructor) {
-                if (exception) {
-                    throw new RuntimeException(String.format("can't parse magic %x in TL_account_password", constructor));
-                } else {
-                    return null;
-                }
+        public static account_Password TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
+            account_Password result = null;
+            switch (constructor) {
+                case 0x957b50fb:
+                    result = new TL_account_password();
+                    break;
+                case 0x185b184f:
+                    result = new TL_account_password_layer144();
+                    break;
             }
-            TL_account_password result = new TL_account_password();
-            result.readParams(stream, exception);
+            if (result == null && exception) {
+                throw new RuntimeException(String.format("can't parse magic %x in account_Password", constructor));
+            }
+            if (result != null) {
+                result.readParams(stream, exception);
+            }
             return result;
         }
+    }
+
+    public static class TL_account_password extends account_Password {
+        public static int constructor = 0x957b50fb;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            has_recovery = (flags & 1) != 0;
+            has_secure_values = (flags & 2) != 0;
+            has_password = (flags & 4) != 0;
+            if ((flags & 4) != 0) {
+                current_algo = PasswordKdfAlgo.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 4) != 0) {
+                srp_B = stream.readByteArray(exception);
+            }
+            if ((flags & 4) != 0) {
+                srp_id = stream.readInt64(exception);
+            }
+            if ((flags & 8) != 0) {
+                hint = stream.readString(exception);
+            }
+            if ((flags & 16) != 0) {
+                email_unconfirmed_pattern = stream.readString(exception);
+            }
+            new_algo = PasswordKdfAlgo.TLdeserialize(stream, stream.readInt32(exception), exception);
+            new_secure_algo = SecurePasswordKdfAlgo.TLdeserialize(stream, stream.readInt32(exception), exception);
+            secure_random = stream.readByteArray(exception);
+            if ((flags & 32) != 0) {
+                pending_reset_date = stream.readInt32(exception);
+            }
+            if ((flags & 64) != 0) {
+                login_email_pattern = stream.readString(exception);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = has_recovery ? (flags | 1) : (flags &~ 1);
+            flags = has_secure_values ? (flags | 2) : (flags &~ 2);
+            flags = has_password ? (flags | 4) : (flags &~ 4);
+            stream.writeInt32(flags);
+            if ((flags & 4) != 0) {
+                current_algo.serializeToStream(stream);
+            }
+            if ((flags & 4) != 0) {
+                stream.writeByteArray(srp_B);
+            }
+            if ((flags & 4) != 0) {
+                stream.writeInt64(srp_id);
+            }
+            if ((flags & 8) != 0) {
+                stream.writeString(hint);
+            }
+            if ((flags & 16) != 0) {
+                stream.writeString(email_unconfirmed_pattern);
+            }
+            new_algo.serializeToStream(stream);
+            new_secure_algo.serializeToStream(stream);
+            stream.writeByteArray(secure_random);
+            if ((flags & 32) != 0) {
+                stream.writeInt32(pending_reset_date);
+            }
+            if ((flags & 64) != 0) {
+                stream.writeString(login_email_pattern);
+            }
+        }
+    }
+
+    public static class TL_account_password_layer144 extends account_Password {
+        public static int constructor = 0x185b184f;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             flags = stream.readInt32(exception);
@@ -30848,9 +34516,9 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = has_recovery ? (flags | 1) : (flags &~ 1);
-            flags = has_secure_values ? (flags | 2) : (flags &~ 2);
-            flags = has_password ? (flags | 4) : (flags &~ 4);
+            flags = has_recovery ? (flags | 1) : (flags & ~1);
+            flags = has_secure_values ? (flags | 2) : (flags & ~2);
+            flags = has_password ? (flags | 4) : (flags & ~4);
             stream.writeInt32(flags);
             if ((flags & 4) != 0) {
                 current_algo.serializeToStream(stream);
@@ -30954,6 +34622,8 @@ public class TLRPC {
         public FileLocation photo_big;
         public byte[] stripped_thumb;
         public int dc_id;
+        public boolean personal;
+        public BitmapDrawable strippedBitmap;
 
         public static UserProfilePhoto TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             UserProfilePhoto result = null;
@@ -31026,6 +34696,13 @@ public class TLRPC {
             photo_big = FileLocation.TLdeserialize(stream, stream.readInt32(exception), exception);
             if ((flags & 2) != 0) {
                 stripped_thumb = stream.readByteArray(exception);
+                if (Build.VERSION.SDK_INT >= 21) {
+                    try {
+                        strippedBitmap = new BitmapDrawable(ImageLoader.getStrippedPhotoBitmap(stripped_thumb, "b"));
+                    } catch (Throwable e) {
+                        FileLog.e(e);
+                    }
+                }
             }
             dc_id = stream.readInt32(exception);
         }
@@ -31114,6 +34791,7 @@ public class TLRPC {
         public void readParams(AbstractSerializedData stream, boolean exception) {
             flags = stream.readInt32(exception);
             has_video = (flags & 1) != 0;
+            personal = (flags & 4) != 0;
             photo_id = stream.readInt64(exception);
             if ((flags & 2) != 0) {
                 stripped_thumb = stream.readByteArray(exception);
@@ -31126,12 +34804,19 @@ public class TLRPC {
             photo_big.volume_id = -photo_id;
             photo_big.local_id = 'c';
 
-
+            if (stripped_thumb != null && Build.VERSION.SDK_INT >= 21) {
+                try {
+                    strippedBitmap = new BitmapDrawable(ImageLoader.getStrippedPhotoBitmap(stripped_thumb, "b"));
+                } catch (Throwable e) {
+                    FileLog.e(e);
+                }
+            }
         }
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
             flags = has_video ? (flags | 1) : (flags &~ 1);
+            flags = personal ? (flags | 4) : (flags & ~4);
             stream.writeInt32(flags);
             stream.writeInt64(photo_id);
             if ((flags & 2) != 0) {
@@ -31183,6 +34868,9 @@ public class TLRPC {
                 case 0x208e68c9:
                     result = new TL_inputMessageEntityMentionName();
                     break;
+                case 0x5eef0214:
+                    result = new TL_messageEntityAnimatedEmoji();
+                    break;
                 case 0x4c4e743f:
                     result = new TL_messageEntityCashtag();
                     break;
@@ -31212,6 +34900,9 @@ public class TLRPC {
                     break;
                 case 0xdc7b1140:
                     result = new TL_messageEntityMentionName();
+                    break;
+                case 0xc8cf05f8:
+                    result = new TL_messageEntityCustomEmoji();
                     break;
             }
             if (result == null && exception) {
@@ -31410,6 +35101,24 @@ public class TLRPC {
 
     public static class TL_messageEntityCashtag extends MessageEntity {
         public static int constructor = 0x4c4e743f;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            offset = stream.readInt32(exception);
+            length = stream.readInt32(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(offset);
+            stream.writeInt32(length);
+        }
+    }
+
+    public static class TL_messageEntityAnimatedEmoji extends MessageEntity {
+        public static int constructor = 0x5eef0214;
+
+        public int offset;
+        public int length;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             offset = stream.readInt32(exception);
@@ -32558,7 +36267,7 @@ public class TLRPC {
     }
 
     public static class TL_config extends TLObject {
-        public static int constructor = 0x330b4067;
+        public static int constructor = 0x232566ac;
 
         public int flags;
         public boolean phonecalls_enabled;
@@ -32568,6 +36277,7 @@ public class TLRPC {
         public boolean revoke_pm_inbox;
         public boolean blocked_mode;
         public boolean pfs_enabled;
+        public boolean force_try_ipv6;
         public int date;
         public int expires;
         public boolean test_mode;
@@ -32612,6 +36322,7 @@ public class TLRPC {
         public String suggested_lang_code;
         public int lang_pack_version;
         public int base_lang_pack_version;
+        public Reaction reactions_default;
 
         public static TL_config TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             if (TL_config.constructor != constructor) {
@@ -32635,6 +36346,7 @@ public class TLRPC {
             revoke_pm_inbox = (flags & 64) != 0;
             blocked_mode = (flags & 256) != 0;
             pfs_enabled = (flags & 8192) != 0;
+            force_try_ipv6 = (flags & 16384) != 0;
             date = stream.readInt32(exception);
             expires = stream.readInt32(exception);
             test_mode = stream.readBool(exception);
@@ -32711,6 +36423,9 @@ public class TLRPC {
             if ((flags & 4) != 0) {
                 base_lang_pack_version = stream.readInt32(exception);
             }
+            if ((flags & 32768) != 0) {
+                reactions_default = Reaction.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
         }
 
         public void serializeToStream(AbstractSerializedData stream) {
@@ -32722,6 +36437,7 @@ public class TLRPC {
             flags = revoke_pm_inbox ? (flags | 64) : (flags &~ 64);
             flags = blocked_mode ? (flags | 256) : (flags &~ 256);
             flags = pfs_enabled ? (flags | 8192) : (flags &~ 8192);
+            flags = force_try_ipv6 ? (flags | 16384) : (flags & ~16384);
             stream.writeInt32(flags);
             stream.writeInt32(date);
             stream.writeInt32(expires);
@@ -32789,6 +36505,9 @@ public class TLRPC {
             }
             if ((flags & 4) != 0) {
                 stream.writeInt32(base_lang_pack_version);
+            }
+            if ((flags & 32768) != 0) {
+                reactions_default.serializeToStream(stream);
             }
         }
     }
@@ -33608,11 +37327,12 @@ public class TLRPC {
         public String username;
         public String password;
         public byte[] peer_tag;
+        public boolean tcp;
 
         public static PhoneConnection TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             PhoneConnection result = null;
             switch (constructor) {
-                case 0x9d4c17c0:
+                case 0x9cc123c7:
                     result = new TL_phoneConnection();
                     break;
                 case 0x635fe375:
@@ -33630,10 +37350,11 @@ public class TLRPC {
     }
 
     public static class TL_phoneConnection extends PhoneConnection {
-        public static int constructor = 0x9d4c17c0;
-
+        public static int constructor = 0x9cc123c7;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            tcp = (flags & 1) != 0;
             id = stream.readInt64(exception);
             ip = stream.readString(exception);
             ipv6 = stream.readString(exception);
@@ -33643,6 +37364,8 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+            flags = tcp ? (flags | 1) : (flags & ~1);
+            stream.writeInt32(flags);
             stream.writeInt64(id);
             stream.writeString(ip);
             stream.writeString(ipv6);
@@ -34364,6 +38087,8 @@ public class TLRPC {
         public String start_param;
         public String message;
         public ArrayList<MessageEntity> entities = new ArrayList<>();
+        public boolean recommended;
+        public boolean show_peer_photo;
 
         public static TL_sponsoredMessage TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             if (TL_sponsoredMessage.constructor != constructor) {
@@ -34380,6 +38105,8 @@ public class TLRPC {
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             flags = stream.readInt32(exception);
+            recommended = (flags & 32) != 0;
+            show_peer_photo = (flags & 64) != 0;
             random_id = stream.readByteArray(exception);
             if ((flags & 8) != 0) {
                 from_id = Peer.TLdeserialize(stream, stream.readInt32(exception), exception);
@@ -34418,6 +38145,8 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+            flags = recommended ? (flags | 32) : (flags & ~32);
+            flags = show_peer_photo ? (flags | 64) : (flags & ~64);
             stream.writeInt32(flags);
             stream.writeByteArray(random_id);
             if ((flags & 8) != 0) {
@@ -35930,6 +39659,7 @@ public class TLRPC {
         public int count;
         public ArrayList<ChannelParticipant> participants = new ArrayList<>();
         public ArrayList<User> users = new ArrayList<>();
+        public ArrayList<Chat> chats = new ArrayList<>();
 
         public static channels_ChannelParticipants TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             channels_ChannelParticipants result = null;
@@ -35953,11 +39683,6 @@ public class TLRPC {
 
     public static class TL_channels_channelParticipants extends channels_ChannelParticipants {
         public static int constructor = 0x9ab0feaf;
-
-        public int count;
-        public ArrayList<ChannelParticipant> participants = new ArrayList<>();
-        public ArrayList<Chat> chats = new ArrayList<>();
-        public ArrayList<User> users = new ArrayList<>();
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             count = stream.readInt32(exception);
@@ -36582,7 +40307,7 @@ public class TLRPC {
     public static abstract class DecryptedMessageMedia extends TLObject {
         public int duration;
         public String mime_type;
-        public int size;
+        public long size;
         public byte[] key;
         public byte[] iv;
         public double lat;
@@ -36623,8 +40348,11 @@ public class TLRPC {
                 case 0x89f5c4a:
                     result = new TL_decryptedMessageMediaEmpty();
                     break;
-                case 0x7afe8ae2:
+                case 0x6abd9782:
                     result = new TL_decryptedMessageMediaDocument();
+                    break;
+                case 0x7afe8ae2:
+                    result = new TL_decryptedMessageMediaDocument_layer101();
                     break;
                 case 0xe50511d8:
                     result = new TL_decryptedMessageMediaWebPage();
@@ -36683,7 +40411,7 @@ public class TLRPC {
             stream.writeInt32(constructor);
             stream.writeInt32(duration);
             stream.writeString(mime_type);
-            stream.writeInt32(size);
+            stream.writeInt32((int) size);
             stream.writeByteArray(key);
             stream.writeByteArray(iv);
         }
@@ -36735,6 +40463,57 @@ public class TLRPC {
     }
 
     public static class TL_decryptedMessageMediaDocument extends DecryptedMessageMedia {
+        public static int constructor = 0x6abd9782;
+
+        public byte[] thumb;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            thumb = stream.readByteArray(exception);
+            thumb_w = stream.readInt32(exception);
+            thumb_h = stream.readInt32(exception);
+            mime_type = stream.readString(exception);
+            size = stream.readInt64(exception);
+            key = stream.readByteArray(exception);
+            iv = stream.readByteArray(exception);
+            int magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            int count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                DocumentAttribute object = DocumentAttribute.TLdeserialize(stream, stream.readInt32(exception),
+                        exception);
+                if (object == null) {
+                    return;
+                }
+                attributes.add(object);
+            }
+            caption = stream.readString(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeByteArray(thumb);
+            stream.writeInt32(thumb_w);
+            stream.writeInt32(thumb_h);
+            stream.writeString(mime_type);
+            stream.writeInt64(size);
+            stream.writeByteArray(key);
+            stream.writeByteArray(iv);
+            stream.writeInt32(0x1cb5c415);
+            int count = attributes.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                attributes.get(a).serializeToStream(stream);
+            }
+            stream.writeString(caption);
+        }
+    }
+
+    public static class TL_decryptedMessageMediaDocument_layer101 extends TL_decryptedMessageMediaDocument {
         public static int constructor = 0x7afe8ae2;
 
         public byte[] thumb;
@@ -36771,7 +40550,7 @@ public class TLRPC {
             stream.writeInt32(thumb_w);
             stream.writeInt32(thumb_h);
             stream.writeString(mime_type);
-            stream.writeInt32(size);
+            stream.writeInt32((int) size);
             stream.writeByteArray(key);
             stream.writeByteArray(iv);
             stream.writeInt32(0x1cb5c415);
@@ -36822,7 +40601,7 @@ public class TLRPC {
             stream.writeInt32(thumb_h);
             stream.writeInt32(w);
             stream.writeInt32(h);
-            stream.writeInt32(size);
+            stream.writeInt32((int) size);
             stream.writeByteArray(key);
             stream.writeByteArray(iv);
             stream.writeString(caption);
@@ -36857,7 +40636,7 @@ public class TLRPC {
             stream.writeString(mime_type);
             stream.writeInt32(w);
             stream.writeInt32(h);
-            stream.writeInt32(size);
+            stream.writeInt32((int) size);
             stream.writeByteArray(key);
             stream.writeByteArray(iv);
             stream.writeString(caption);
@@ -36887,7 +40666,7 @@ public class TLRPC {
             stream.writeInt32(thumb_h);
             stream.writeString(file_name);
             stream.writeString(mime_type);
-            stream.writeInt32(size);
+            stream.writeInt32((int) size);
             stream.writeByteArray(key);
             stream.writeByteArray(iv);
         }
@@ -36918,7 +40697,7 @@ public class TLRPC {
             stream.writeInt32(duration);
             stream.writeInt32(w);
             stream.writeInt32(h);
-            stream.writeInt32(size);
+            stream.writeInt32((int) size);
             stream.writeByteArray(key);
             stream.writeByteArray(iv);
         }
@@ -36984,7 +40763,7 @@ public class TLRPC {
             stream.writeInt64(access_hash);
             stream.writeInt32(date);
             stream.writeString(mime_type);
-            stream.writeInt32(size);
+            stream.writeInt32((int) size);
             thumb.serializeToStream(stream);
             stream.writeInt32(dc_id);
             stream.writeInt32(0x1cb5c415);
@@ -37023,7 +40802,7 @@ public class TLRPC {
             stream.writeString(mime_type);
             stream.writeInt32(w);
             stream.writeInt32(h);
-            stream.writeInt32(size);
+            stream.writeInt32((int) size);
             stream.writeByteArray(key);
             stream.writeByteArray(iv);
         }
@@ -37043,7 +40822,7 @@ public class TLRPC {
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
             stream.writeInt32(duration);
-            stream.writeInt32(size);
+            stream.writeInt32((int) size);
             stream.writeByteArray(key);
             stream.writeByteArray(iv);
         }
@@ -37072,7 +40851,7 @@ public class TLRPC {
             stream.writeInt32(thumb_h);
             stream.writeInt32(w);
             stream.writeInt32(h);
-            stream.writeInt32(size);
+            stream.writeInt32((int) size);
             stream.writeByteArray(key);
             stream.writeByteArray(iv);
         }
@@ -37133,6 +40912,124 @@ public class TLRPC {
         }
     }
 
+    public static abstract class messages_EmojiGroups extends TLObject {
+
+        public static messages_EmojiGroups TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
+            messages_EmojiGroups result = null;
+            switch (constructor) {
+                case 0x6fb4ad87:
+                    result = new TL_messages_emojiGroupsNotModified();
+                    break;
+                case 0x881fb94b:
+                    result = new TL_messages_emojiGroups();
+                    break;
+            }
+            if (result == null && exception) {
+                throw new RuntimeException(String.format("can't parse magic %x in messages_EmojiGroups", constructor));
+            }
+            if (result != null) {
+                result.readParams(stream, exception);
+            }
+            return result;
+        }
+    }
+
+    public static class TL_messages_emojiGroupsNotModified extends messages_EmojiGroups {
+        public static int constructor = 0x6fb4ad87;
+
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
+    public static class TL_messages_emojiGroups extends messages_EmojiGroups {
+        public static int constructor = 0x881fb94b;
+
+        public int hash;
+        public ArrayList<TL_emojiGroup> groups = new ArrayList<>();
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            hash = stream.readInt32(exception);
+            int magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            int count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                TL_emojiGroup object = TL_emojiGroup.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                groups.add(object);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(hash);
+            stream.writeInt32(0x1cb5c415);
+            int count = groups.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                groups.get(a).serializeToStream(stream);
+            }
+        }
+    }
+
+    public static class TL_emojiGroup extends TLObject {
+        public static int constructor = 0x7a9abda9;
+
+        public String title;
+        public long icon_emoji_id;
+        public ArrayList<String> emoticons = new ArrayList<>();
+
+        public static TL_emojiGroup TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+            if (TL_emojiGroup.constructor != constructor) {
+                if (exception) {
+                    throw new RuntimeException(String.format("can't parse magic %x in TL_emojiGroup", constructor));
+                } else {
+                    return null;
+                }
+            }
+            TL_emojiGroup result = new TL_emojiGroup();
+            result.readParams(stream, exception);
+            return result;
+        }
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            title = stream.readString(exception);
+            icon_emoji_id = stream.readInt64(exception);
+            int magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            int count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                emoticons.add(stream.readString(exception));
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeString(title);
+            stream.writeInt64(icon_emoji_id);
+            stream.writeInt32(0x1cb5c415);
+            int count = emoticons.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                stream.writeString(emoticons.get(a));
+            }
+        }
+    }
+
     public static class TL_emojiKeyword extends EmojiKeyword {
         public static int constructor = 0xd5b3b9f9;
 
@@ -37173,10 +41070,12 @@ public class TLRPC {
         public TL_autoDownloadSettings medium;
         public TL_autoDownloadSettings high;
 
-        public static TL_account_autoDownloadSettings TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+        public static TL_account_autoDownloadSettings TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
             if (TL_account_autoDownloadSettings.constructor != constructor) {
                 if (exception) {
-                    throw new RuntimeException(String.format("can't parse magic %x in TL_account_autoDownloadSettings", constructor));
+                    throw new RuntimeException(
+                            String.format("can't parse magic %x in TL_account_autoDownloadSettings", constructor));
                 } else {
                     return null;
                 }
@@ -37343,6 +41242,7 @@ public class TLRPC {
 
         public int flags;
         public boolean inactive;
+        public boolean premium;
         public String reaction;
         public String title;
         public Document static_icon;
@@ -37370,6 +41270,7 @@ public class TLRPC {
         public void readParams(AbstractSerializedData stream, boolean exception) {
             flags = stream.readInt32(exception);
             inactive = (flags & 1) != 0;
+            premium = (flags & 4) != 0;
             reaction = stream.readString(exception);
             title = stream.readString(exception);
             static_icon = Document.TLdeserialize(stream, stream.readInt32(exception), exception);
@@ -37388,6 +41289,7 @@ public class TLRPC {
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
             flags = inactive ? (flags | 1) : (flags &~ 1);
+            flags = premium ? (flags | 4) : (flags & ~4);
             stream.writeInt32(flags);
             stream.writeString(reaction);
             stream.writeString(title);
@@ -37629,6 +41531,15 @@ public class TLRPC {
                 case 0x3e7f6847:
                     result = new TL_channelAdminLogEventActionParticipantVolume();
                     break;
+                case 0x2cc6383:
+                    result = new TL_channelAdminLogEventActionToggleForum();
+                    break;
+                case 0xf06fe208:
+                    result = new TL_channelAdminLogEventActionEditTopic();
+                    break;
+                case 0x5d8d353b:
+                    result = new TL_channelAdminLogEventActionPinTopic();
+                    break;
                 case 0xe6d83d7e:
                     result = new TL_channelAdminLogEventActionParticipantToggleBan();
                     break;
@@ -37656,7 +41567,7 @@ public class TLRPC {
                 case 0x23209745:
                     result = new TL_channelAdminLogEventActionStartGroupCall();
                     break;
-                case 0x9cf7f76a:
+                case 0xbe4e0ef8:
                     result = new TL_channelAdminLogEventActionChangeAvailableReactions();
                     break;
                 case 0x50c7ac8:
@@ -37679,6 +41590,18 @@ public class TLRPC {
                     break;
                 case 0xcb2ac766:
                     result = new TL_channelAdminLogEventActionToggleNoForwards();
+                    break;
+                case 0xf04fb3a9:
+                    result = new TL_channelAdminLogEventActionChangeUsernames();
+                    break;
+                case 0x58707d28:
+                    result = new TL_channelAdminLogEventActionCreateTopic();
+                    break;
+                case 0xae168909:
+                    result = new TL_channelAdminLogEventActionDeleteTopic();
+                    break;
+                case 0x64f36dfc:
+                    result = new TL_channelAdminLogEventActionToggleAntiSpam();
                     break;
             }
             if (result == null && exception) {
@@ -37916,7 +41839,7 @@ public class TLRPC {
         public TL_chatInviteExported invite;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
-            invite = (TL_chatInviteExported) ExportedChatInvite.TLdeserialize(stream, stream.readInt32(exception), exception);
+            invite = ExportedChatInvite.TLdeserialize(stream, stream.readInt32(exception), exception);
         }
 
         public void serializeToStream(AbstractSerializedData stream) {
@@ -37997,6 +41920,39 @@ public class TLRPC {
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
             participant.serializeToStream(stream);
+        }
+    }
+
+    public static class TL_channelAdminLogEventActionToggleForum extends ChannelAdminLogEventAction {
+        public static int constructor = 0x2cc6383;
+
+        public boolean new_value;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            new_value = stream.readBool(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeBool(new_value);
+        }
+    }
+
+    public static class TL_channelAdminLogEventActionEditTopic extends ChannelAdminLogEventAction {
+        public static int constructor = 0xf06fe208;
+
+        public ForumTopic prev_topic;
+        public ForumTopic new_topic;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            prev_topic = ForumTopic.TLdeserialize(stream, stream.readInt32(exception), exception);
+            new_topic = ForumTopic.TLdeserialize(stream, stream.readInt32(exception), exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            prev_topic.serializeToStream(stream);
+            new_topic.serializeToStream(stream);
         }
     }
 
@@ -38172,50 +42128,20 @@ public class TLRPC {
     }
 
     public static class TL_channelAdminLogEventActionChangeAvailableReactions extends ChannelAdminLogEventAction {
-        public static int constructor = 0x9cf7f76a;
+        public static int constructor = 0xbe4e0ef8;
 
-        public ArrayList<String> prev_value = new ArrayList<>();
-        public ArrayList<String> new_value = new ArrayList<>();
+        public ChatReactions prev_value;
+        public ChatReactions new_value;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
-            int magic = stream.readInt32(exception);
-            if (magic != 0x1cb5c415) {
-                if (exception) {
-                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
-                }
-                return;
-            }
-            int count = stream.readInt32(exception);
-            for (int a = 0; a < count; a++) {
-                prev_value.add(stream.readString(exception));
-            }
-            magic = stream.readInt32(exception);
-            if (magic != 0x1cb5c415) {
-                if (exception) {
-                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
-                }
-                return;
-            }
-            count = stream.readInt32(exception);
-            for (int a = 0; a < count; a++) {
-                new_value.add(stream.readString(exception));
-            }
+            prev_value = ChatReactions.TLdeserialize(stream, stream.readInt32(exception), exception);
+            new_value = ChatReactions.TLdeserialize(stream, stream.readInt32(exception), exception);
         }
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            stream.writeInt32(0x1cb5c415);
-            int count = prev_value.size();
-            stream.writeInt32(count);
-            for (int a = 0; a < count; a++) {
-                stream.writeString(prev_value.get(a));
-            }
-            stream.writeInt32(0x1cb5c415);
-            count = new_value.size();
-            stream.writeInt32(count);
-            for (int a = 0; a < count; a++) {
-                stream.writeString(new_value.get(a));
-            }
+            prev_value.serializeToStream(stream);
+            new_value.serializeToStream(stream);
         }
     }
 
@@ -38282,6 +42208,35 @@ public class TLRPC {
         }
     }
 
+    public static class TL_channelAdminLogEventActionPinTopic extends ChannelAdminLogEventAction {
+        public static int constructor = 0x5d8d353b;
+
+        public int flags;
+        public ForumTopic prev_topic;
+        public ForumTopic new_topic;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            if ((flags & 1) != 0) {
+                prev_topic = ForumTopic.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 2) != 0) {
+                new_topic = ForumTopic.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(flags);
+            if ((flags & 1) != 0) {
+                prev_topic.serializeToStream(stream);
+            }
+            if ((flags & 2) != 0) {
+                new_topic.serializeToStream(stream);
+            }
+        }
+    }
+
     public static class TL_channelAdminLogEventActionChangeHistoryTTL extends ChannelAdminLogEventAction {
         public static int constructor = 0x6e941a38;
 
@@ -38315,9 +42270,102 @@ public class TLRPC {
         }
     }
 
+    public static class TL_channelAdminLogEventActionCreateTopic extends ChannelAdminLogEventAction {
+        public static int constructor = 0x58707d28;
+
+        public ForumTopic topic;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            topic = ForumTopic.TLdeserialize(stream, stream.readInt32(exception), exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            topic.serializeToStream(stream);
+        }
+    }
+
+    public static class TL_channelAdminLogEventActionDeleteTopic extends ChannelAdminLogEventAction {
+        public static int constructor = 0xae168909;
+
+        public ForumTopic topic;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            topic = ForumTopic.TLdeserialize(stream, stream.readInt32(exception), exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            topic.serializeToStream(stream);
+        }
+    }
+
+    public static class TL_channelAdminLogEventActionChangeUsernames extends ChannelAdminLogEventAction {
+        public static int constructor = 0xf04fb3a9;
+
+        public ArrayList<String> prev_value = new ArrayList<>();
+        public ArrayList<String> new_value = new ArrayList<>();
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            int magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            int count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                prev_value.add(stream.readString(exception));
+            }
+
+            magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                new_value.add(stream.readString(exception));
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(0x1cb5c415);
+            stream.writeInt32(prev_value.size());
+            for (int i = 0; i < prev_value.size(); ++i) {
+                stream.writeString(prev_value.get(i));
+            }
+            stream.writeInt32(0x1cb5c415);
+            stream.writeInt32(new_value.size());
+            for (int i = 0; i < new_value.size(); ++i) {
+                stream.writeString(new_value.get(i));
+            }
+        }
+    }
+
+    public static class TL_channelAdminLogEventActionToggleAntiSpam extends ChannelAdminLogEventAction {
+        public static int constructor = 0x64f36dfc;
+
+        public boolean new_value;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            new_value = stream.readBool(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeBool(new_value);
+        }
+    }
+
     public static abstract class InputWebFileLocation extends TLObject {
 
-        public static InputWebFileLocation TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+        public static InputWebFileLocation TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
             InputWebFileLocation result = null;
             switch (constructor) {
                 case 0x9f2221c9:
@@ -38475,7 +42523,7 @@ public class TLRPC {
     }
 
     public static class TL_autoDownloadSettings extends TLObject {
-        public static int constructor = 0xe04232f3;
+        public static int constructor = 0x8efab953;
 
         public int flags;
         public boolean disabled;
@@ -38483,8 +42531,8 @@ public class TLRPC {
         public boolean audio_preload_next;
         public boolean phonecalls_less_data;
         public int photo_size_max;
-        public int video_size_max;
-        public int file_size_max;
+        public long video_size_max;
+        public long file_size_max;
         public int video_upload_maxbitrate;
 
         public static TL_autoDownloadSettings TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
@@ -38507,8 +42555,8 @@ public class TLRPC {
             audio_preload_next = (flags & 4) != 0;
             phonecalls_less_data = (flags & 8) != 0;
             photo_size_max = stream.readInt32(exception);
-            video_size_max = stream.readInt32(exception);
-            file_size_max = stream.readInt32(exception);
+            video_size_max = stream.readInt64(exception);
+            file_size_max = stream.readInt64(exception);
             video_upload_maxbitrate = stream.readInt32(exception);
         }
 
@@ -38520,8 +42568,8 @@ public class TLRPC {
             flags = phonecalls_less_data ? (flags | 8) : (flags &~ 8);
             stream.writeInt32(flags);
             stream.writeInt32(photo_size_max);
-            stream.writeInt32(video_size_max);
-            stream.writeInt32(file_size_max);
+            stream.writeInt64(video_size_max);
+            stream.writeInt64(file_size_max);
             stream.writeInt32(video_upload_maxbitrate);
         }
     }
@@ -38704,6 +42752,7 @@ public class TLRPC {
         public String title;
         public int date;
         public int flags;
+        public int flags2;
         public boolean creator;
         public boolean kicked;
         public boolean deactivated;
@@ -38731,6 +42780,7 @@ public class TLRPC {
         public boolean fake;
         public boolean gigagroup;
         public boolean noforwards;
+        public boolean forum;
         public ArrayList<TL_restrictionReason> restriction_reason = new ArrayList<>();
         public TL_channelAdminRights_layer92 admin_rights_layer92;
         public TL_channelBannedRights_layer92 banned_rights_layer92;
@@ -38738,6 +42788,10 @@ public class TLRPC {
         public TL_chatBannedRights banned_rights;
         public TL_chatBannedRights default_banned_rights;
         public InputChannel migrated_to;
+        public boolean join_to_send;
+        public boolean join_request;
+
+        public ArrayList<TL_username> usernames = new ArrayList<>();
 
         public static Chat TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             Chat result = null;
@@ -38799,8 +42853,11 @@ public class TLRPC {
                 case 0xa14dca52:
                     result = new TL_channel_layer67();
                     break;
-                case 0x8261ac61:
+                case 0x83259464:
                     result = new TL_channel();
+                    break;
+                case 0x8261ac61:
+                    result = new TL_channel_layer147();
                     break;
                 case 0xfb0ccc41:
                     result = new TL_chatForbidden_old();
@@ -39182,8 +43239,7 @@ public class TLRPC {
     }
 
     public static class TL_channel extends Chat {
-        public static int constructor = 0x8261ac61;
-
+        public static int constructor = 0x83259464;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             flags = stream.readInt32(exception);
@@ -39204,6 +43260,10 @@ public class TLRPC {
             fake = (flags & 33554432) != 0;
             gigagroup = (flags & 67108864) != 0;
             noforwards = (flags & 134217728) != 0;
+            join_to_send = (flags & 268435456) != 0;
+            join_request = (flags & 536870912) != 0;
+            forum = (flags & 1073741824) != 0;
+            flags2 = stream.readInt32(exception);
             id = stream.readInt64(exception);
             if ((flags & 8192) != 0) {
                 access_hash = stream.readInt64(exception);
@@ -39243,6 +43303,23 @@ public class TLRPC {
             if ((flags & 131072) != 0) {
                 participants_count = stream.readInt32(exception);
             }
+            if ((flags2 & 1) != 0) {
+                int magic = stream.readInt32(exception);
+                if (magic != 0x1cb5c415) {
+                    if (exception) {
+                        throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                    }
+                    return;
+                }
+                int count = stream.readInt32(exception);
+                for (int a = 0; a < count; a++) {
+                    TL_username object = TL_username.TLdeserialize(stream, stream.readInt32(exception), exception);
+                    if (object == null) {
+                        return;
+                    }
+                    usernames.add(object);
+                }
+            }
         }
 
         public void serializeToStream(AbstractSerializedData stream) {
@@ -39264,6 +43341,143 @@ public class TLRPC {
             flags = fake ? (flags | 33554432) : (flags &~ 33554432);
             flags = gigagroup ? (flags | 67108864) : (flags &~ 67108864);
             flags = noforwards ? (flags | 134217728) : (flags &~ 134217728);
+            flags = join_to_send ? (flags | 268435456) : (flags & ~268435456);
+            flags = join_request ? (flags | 536870912) : (flags & ~536870912);
+            flags = forum ? (flags | 1073741824) : (flags & ~1073741824);
+            stream.writeInt32(flags);
+            stream.writeInt32(flags2);
+            stream.writeInt64(id);
+            if ((flags & 8192) != 0) {
+                stream.writeInt64(access_hash);
+            }
+            stream.writeString(title);
+            if ((flags & 64) != 0) {
+                stream.writeString(username);
+            }
+            photo.serializeToStream(stream);
+            stream.writeInt32(date);
+            if ((flags & 512) != 0) {
+                stream.writeInt32(0x1cb5c415);
+                int count = restriction_reason.size();
+                stream.writeInt32(count);
+                for (int a = 0; a < count; a++) {
+                    restriction_reason.get(a).serializeToStream(stream);
+                }
+            }
+            if ((flags & 16384) != 0) {
+                admin_rights.serializeToStream(stream);
+            }
+            if ((flags & 32768) != 0) {
+                banned_rights.serializeToStream(stream);
+            }
+            if ((flags & 262144) != 0) {
+                default_banned_rights.serializeToStream(stream);
+            }
+            if ((flags & 131072) != 0) {
+                stream.writeInt32(participants_count);
+            }
+            if ((flags2 & 1) != 0) {
+                stream.writeInt32(0x1cb5c415);
+                int count = usernames.size();
+                stream.writeInt32(count);
+                for (int a = 0; a < count; a++) {
+                    usernames.get(a).serializeToStream(stream);
+                }
+            }
+        }
+    }
+
+    public static class TL_channel_layer147 extends TL_channel {
+        public static int constructor = 0x8261ac61;
+
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            creator = (flags & 1) != 0;
+            left = (flags & 4) != 0;
+            broadcast = (flags & 32) != 0;
+            verified = (flags & 128) != 0;
+            megagroup = (flags & 256) != 0;
+            restricted = (flags & 512) != 0;
+            signatures = (flags & 2048) != 0;
+            min = (flags & 4096) != 0;
+            scam = (flags & 524288) != 0;
+            has_link = (flags & 1048576) != 0;
+            has_geo = (flags & 2097152) != 0;
+            slowmode_enabled = (flags & 4194304) != 0;
+            call_active = (flags & 8388608) != 0;
+            call_not_empty = (flags & 16777216) != 0;
+            fake = (flags & 33554432) != 0;
+            gigagroup = (flags & 67108864) != 0;
+            noforwards = (flags & 134217728) != 0;
+            join_to_send = (flags & 268435456) != 0;
+            join_request = (flags & 536870912) != 0;
+            forum = (flags & 1073741824) != 0;
+            id = stream.readInt64(exception);
+            if ((flags & 8192) != 0) {
+                access_hash = stream.readInt64(exception);
+            }
+            title = stream.readString(exception);
+            if ((flags & 64) != 0) {
+                username = stream.readString(exception);
+            }
+            photo = ChatPhoto.TLdeserialize(stream, stream.readInt32(exception), exception);
+            date = stream.readInt32(exception);
+            if ((flags & 512) != 0) {
+                int magic = stream.readInt32(exception);
+                if (magic != 0x1cb5c415) {
+                    if (exception) {
+                        throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                    }
+                    return;
+                }
+                int count = stream.readInt32(exception);
+                for (int a = 0; a < count; a++) {
+                    TL_restrictionReason object = TL_restrictionReason.TLdeserialize(stream,
+                            stream.readInt32(exception), exception);
+                    if (object == null) {
+                        return;
+                    }
+                    restriction_reason.add(object);
+                }
+            }
+            if ((flags & 16384) != 0) {
+                admin_rights = TL_chatAdminRights.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 32768) != 0) {
+                banned_rights = TL_chatBannedRights.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 262144) != 0) {
+                default_banned_rights = TL_chatBannedRights.TLdeserialize(stream, stream.readInt32(exception),
+                        exception);
+            }
+            if ((flags & 131072) != 0) {
+                participants_count = stream.readInt32(exception);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = creator ? (flags | 1) : (flags &~ 1);
+            flags = left ? (flags | 4) : (flags &~ 4);
+            flags = broadcast ? (flags | 32) : (flags & ~32);
+            flags = verified ? (flags | 128) : (flags & ~128);
+            flags = megagroup ? (flags | 256) : (flags & ~256);
+            flags = restricted ? (flags | 512) : (flags & ~512);
+            flags = signatures ? (flags | 2048) : (flags & ~2048);
+            flags = min ? (flags | 4096) : (flags & ~4096);
+            flags = scam ? (flags | 524288) : (flags & ~524288);
+            flags = has_link ? (flags | 1048576) : (flags & ~1048576);
+            flags = has_geo ? (flags | 2097152) : (flags & ~2097152);
+            flags = slowmode_enabled ? (flags | 4194304) : (flags & ~4194304);
+            flags = call_active ? (flags | 8388608) : (flags & ~8388608);
+            flags = call_not_empty ? (flags | 16777216) : (flags & ~16777216);
+            flags = fake ? (flags | 33554432) : (flags & ~33554432);
+            flags = gigagroup ? (flags | 67108864) : (flags & ~67108864);
+            flags = noforwards ? (flags | 134217728) : (flags & ~134217728);
+            flags = join_to_send ? (flags | 268435456) : (flags & ~268435456);
+            flags = join_request ? (flags | 536870912) : (flags & ~536870912);
+            flags = forum ? (flags | 1073741824) : (flags & ~1073741824);
             stream.writeInt32(flags);
             stream.writeInt64(id);
             if ((flags & 8192) != 0) {
@@ -39363,9 +43577,9 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = creator ? (flags | 1) : (flags &~ 1);
-            flags = kicked ? (flags | 2) : (flags &~ 2);
-            flags = left ? (flags | 4) : (flags &~ 4);
+            flags = creator ? (flags | 1) : (flags & ~1);
+            flags = kicked ? (flags | 2) : (flags & ~2);
+            flags = left ? (flags | 4) : (flags & ~4);
             flags = moderator ? (flags | 16) : (flags &~ 16);
             flags = broadcast ? (flags | 32) : (flags &~ 32);
             flags = verified ? (flags | 128) : (flags &~ 128);
@@ -40003,6 +44217,8 @@ public class TLRPC {
         public boolean official;
         public boolean animated;
         public boolean masks;
+        public boolean videos;
+        public boolean emojis;
         public long id;
         public long access_hash;
         public String title;
@@ -40013,6 +44229,7 @@ public class TLRPC {
         public ArrayList<PhotoSize> thumbs = new ArrayList<>();
         public int thumb_dc_id;
         public int thumb_version;
+        public long thumb_document_id;
         public boolean gifs;
 
         public static StickerSet TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
@@ -40037,6 +44254,9 @@ public class TLRPC {
                     result = new TL_stickerSet_layer75();
                     break;
                 case 0xd7df217a:
+                    result = new TL_stickerSet_layer143();
+                    break;
+                case 0x2dd14edc:
                     result = new TL_stickerSet();
                     break;
             }
@@ -40071,6 +44291,93 @@ public class TLRPC {
     }
 
     public static class TL_stickerSet extends StickerSet {
+        public static int constructor = 0x2dd14edc;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            archived = (flags & 2) != 0;
+            official = (flags & 4) != 0;
+            masks = (flags & 8) != 0;
+            animated = (flags & 32) != 0;
+            videos = (flags & 64) != 0;
+            emojis = (flags & 128) != 0;
+            if ((flags & 1) != 0) {
+                installed_date = stream.readInt32(exception);
+            }
+            id = stream.readInt64(exception);
+            access_hash = stream.readInt64(exception);
+            title = stream.readString(exception);
+            short_name = stream.readString(exception);
+            if ((flags & 16) != 0) {
+                int magic = stream.readInt32(exception);
+                if (magic != 0x1cb5c415) {
+                    if (exception) {
+                        throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                    }
+                    return;
+                }
+                int count = stream.readInt32(exception);
+                for (int a = 0; a < count; a++) {
+                    PhotoSize object = PhotoSize.TLdeserialize(0, 0, id, stream, stream.readInt32(exception),
+                            exception);
+                    if (object == null) {
+                        return;
+                    }
+                    thumbs.add(object);
+                }
+            }
+            if ((flags & 16) != 0) {
+                thumb_dc_id = stream.readInt32(exception);
+            }
+            if ((flags & 16) != 0) {
+                thumb_version = stream.readInt32(exception);
+            }
+            if ((flags & 256) != 0) {
+                thumb_document_id = stream.readInt64(exception);
+            }
+            count = stream.readInt32(exception);
+            hash = stream.readInt32(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = archived ? (flags | 2) : (flags & ~2);
+            flags = official ? (flags | 4) : (flags & ~4);
+            flags = masks ? (flags | 8) : (flags & ~8);
+            flags = animated ? (flags | 32) : (flags & ~32);
+            flags = videos ? (flags | 64) : (flags & ~64);
+            flags = emojis ? (flags | 128) : (flags & ~128);
+            stream.writeInt32(flags);
+            if ((flags & 1) != 0) {
+                stream.writeInt32(installed_date);
+            }
+            stream.writeInt64(id);
+            stream.writeInt64(access_hash);
+            stream.writeString(title);
+            stream.writeString(short_name);
+            if ((flags & 16) != 0) {
+                stream.writeInt32(0x1cb5c415);
+                int count = thumbs.size();
+                stream.writeInt32(count);
+                for (int a = 0; a < count; a++) {
+                    thumbs.get(a).serializeToStream(stream);
+                }
+            }
+            if ((flags & 16) != 0) {
+                stream.writeInt32(thumb_dc_id);
+            }
+            if ((flags & 16) != 0) {
+                stream.writeInt32(thumb_version);
+            }
+            if ((flags & 256) != 0) {
+                stream.writeInt64(thumb_document_id);
+            }
+            stream.writeInt32(count);
+            stream.writeInt32(hash);
+        }
+    }
+
+    public static class TL_stickerSet_layer143 extends TL_stickerSet {
         public static int constructor = 0xd7df217a;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
@@ -40079,7 +44386,8 @@ public class TLRPC {
             official = (flags & 4) != 0;
             masks = (flags & 8) != 0;
             animated = (flags & 32) != 0;
-            gifs = (flags & 64) != 0;
+            videos = (flags & 64) != 0;
+            emojis = (flags & 128) != 0;
             if ((flags & 1) != 0) {
                 installed_date = stream.readInt32(exception);
             }
@@ -40110,6 +44418,9 @@ public class TLRPC {
             if ((flags & 16) != 0) {
                 thumb_version = stream.readInt32(exception);
             }
+            if ((flags & 256) != 0) {
+                thumb_document_id = stream.readInt64(exception);
+            }
             count = stream.readInt32(exception);
             hash = stream.readInt32(exception);
         }
@@ -40120,7 +44431,8 @@ public class TLRPC {
             flags = official ? (flags | 4) : (flags &~ 4);
             flags = masks ? (flags | 8) : (flags &~ 8);
             flags = animated ? (flags | 32) : (flags &~ 32);
-            flags = gifs ? (flags | 64) : (flags & ~64);
+            flags = videos ? (flags | 64) : (flags & ~64);
+            flags = emojis ? (flags | 128) : (flags & ~128);
             stream.writeInt32(flags);
             if ((flags & 1) != 0) {
                 stream.writeInt32(installed_date);
@@ -40142,6 +44454,9 @@ public class TLRPC {
             }
             if ((flags & 16) != 0) {
                 stream.writeInt32(thumb_version);
+            }
+            if ((flags & 256) != 0) {
+                stream.writeInt64(thumb_document_id);
             }
             stream.writeInt32(count);
             stream.writeInt32(hash);
@@ -40546,6 +44861,9 @@ public class TLRPC {
                 case 0xd61ad6ee:
                     result = new TL_auth_codeTypeMissedCall();
                     break;
+                case 0x6ed998c:
+                    result = new TL_auth_codeTypeFragmentSms();
+                    break;
             }
             if (result == null && exception) {
                 throw new RuntimeException(String.format("can't parse magic %x in auth_CodeType", constructor));
@@ -40593,50 +44911,62 @@ public class TLRPC {
         }
     }
 
-    public static abstract class messages_TranslatedText extends TLObject {
+    public static class TL_auth_codeTypeFragmentSms extends auth_CodeType {
+        public static int constructor = 0x6ed998c;
 
-        public static messages_TranslatedText TLdeserialize(AbstractSerializedData stream, int constructor,
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
+    public static class TL_messages_translateResult extends TLObject {
+        public static int constructor = 0x33db32f8;
+
+        public ArrayList<TL_textWithEntities> result = new ArrayList<>();
+
+        public static TL_messages_translateResult TLdeserialize(AbstractSerializedData stream, int constructor,
                 boolean exception) {
-            messages_TranslatedText result = null;
-            switch (constructor) {
-                case 0x67ca4737:
-                    result = new TL_messages_translateNoResult();
-                    break;
-                case 0xa214f7d0:
-                    result = new TL_messages_translateResultText();
-                    break;
+            if (TL_messages_translateResult.constructor != constructor) {
+                if (exception) {
+                    throw new RuntimeException(
+                            String.format("can't parse magic %x in TL_messages_translateResult", constructor));
+                } else {
+                    return null;
+                }
             }
-            if (result == null && exception) {
-                throw new RuntimeException(
-                        String.format("can't parse magic %x in messages_TranslatedText", constructor));
-            }
-            if (result != null) {
-                result.readParams(stream, exception);
-            }
+            TL_messages_translateResult result = new TL_messages_translateResult();
+            result.readParams(stream, exception);
             return result;
         }
-    }
-
-    public static class TL_messages_translateNoResult extends messages_TranslatedText {
-        public static int constructor = 0x67ca4737;
-
-        public void serializeToStream(AbstractSerializedData stream) {
-            stream.writeInt32(constructor);
-        }
-    }
-
-    public static class TL_messages_translateResultText extends messages_TranslatedText {
-        public static int constructor = 0xa214f7d0;
-
-        public String text;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
-            text = stream.readString(exception);
+            int magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            int count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                TL_textWithEntities object = TL_textWithEntities.TLdeserialize(stream, stream.readInt32(exception),
+                        exception);
+                if (object == null) {
+                    return;
+                }
+                result.add(object);
+            }
         }
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            stream.writeString(text);
+            stream.writeInt32(0x1cb5c415);
+            int count = result.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                result.get(a).serializeToStream(stream);
+            }
         }
     }
 
@@ -41965,6 +46295,9 @@ public class TLRPC {
                 case 0xfc2e05bc:
                     result = new TL_chatInviteExported_layer122();
                     break;
+                case 0xed107ab7:
+                    result = new TL_chatInvitePublicJoinRequests();
+                    break;
             }
             if (result == null && exception) {
                 throw new RuntimeException(String.format("can't parse magic %x in ExportedChatInvite", constructor));
@@ -42235,6 +46568,58 @@ public class TLRPC {
         }
     }
 
+    public static class TL_textWithEntities extends TLObject {
+        public static int constructor = 0x751f3146;
+
+        public String text;
+        public ArrayList<MessageEntity> entities = new ArrayList<>();
+
+        public static TL_textWithEntities TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
+            if (TL_textWithEntities.constructor != constructor) {
+                if (exception) {
+                    throw new RuntimeException(
+                            String.format("can't parse magic %x in TL_textWithEntities", constructor));
+                } else {
+                    return null;
+                }
+            }
+            TL_textWithEntities result = new TL_textWithEntities();
+            result.readParams(stream, exception);
+            return result;
+        }
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            text = stream.readString(exception);
+            int magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            int count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                MessageEntity object = MessageEntity.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                entities.add(object);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeString(text);
+            stream.writeInt32(0x1cb5c415);
+            int count = entities.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                entities.get(a).serializeToStream(stream);
+            }
+        }
+    }
+
     public static class TL_account_webAuthorizations extends TLObject {
         public static int constructor = 0xed56c9fc;
 
@@ -42344,39 +46729,51 @@ public class TLRPC {
         }
     }
 
-    public static class TL_reactionCount extends TLObject {
-        public static int constructor = 0x6fb250d1;
+    public static abstract class ReactionCount extends TLObject {
 
         public int flags;
-        public boolean chosen;
-        public String reaction;
+        public int chosen_order;
+        public boolean chosen; // custom
+        public int lastDrawnPosition;
+        public Reaction reaction;
         public int count;
 
-        public static TL_reactionCount TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
-            if (TL_reactionCount.constructor != constructor) {
-                if (exception) {
-                    throw new RuntimeException(String.format("can't parse magic %x in TL_reactionCount", constructor));
-                } else {
-                    return null;
-                }
+        public static ReactionCount TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+            ReactionCount result = null;
+            switch (constructor) {
+                case 0xa3d1cb80:
+                    result = new TL_reactionCount();
+                    break;
             }
-            TL_reactionCount result = new TL_reactionCount();
-            result.readParams(stream, exception);
+            if (result == null && exception) {
+                throw new RuntimeException(String.format("can't parse magic %x in ReactionCount", constructor));
+            }
+            if (result != null) {
+                result.readParams(stream, exception);
+            }
             return result;
         }
+    }
+
+    public static class TL_reactionCount extends ReactionCount {
+        public static int constructor = 0xa3d1cb80;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             flags = stream.readInt32(exception);
-            chosen = (flags & 1) != 0;
-            reaction = stream.readString(exception);
+            if (chosen = (flags & 1) != 0) {
+                chosen_order = stream.readInt32(exception);
+            }
+            reaction = Reaction.TLdeserialize(stream, stream.readInt32(exception), exception);
             count = stream.readInt32(exception);
         }
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = chosen ? (flags | 1) : (flags &~ 1);
             stream.writeInt32(flags);
-            stream.writeString(reaction);
+            if ((flags & 1) != 0) {
+                stream.writeInt32(chosen_order);
+            }
+            reaction.serializeToStream(stream);
             stream.writeInt32(count);
         }
     }
@@ -42458,9 +46855,12 @@ public class TLRPC {
         public boolean can_pin_message;
         public boolean has_scheduled;
         public boolean video_calls_available;
+        public boolean voice_messages_forbidden;
+        public boolean translations_disabled;
         public User user;
         public String about;
         public TL_contacts_link_layer101 link;
+        public Photo personal_photo;
         public Photo profile_photo;
         public PeerNotifySettings notify_settings;
         public BotInfo bot_info;
@@ -42474,12 +46874,23 @@ public class TLRPC {
         public String private_forward_name;
         public TL_chatAdminRights bot_group_admin_rights;
         public TL_chatAdminRights bot_broadcast_admin_rights;
+        public ArrayList<TL_premiumGiftOption> premium_gifts = new ArrayList<>();
+        public Photo fallback_photo;
 
         public static UserFull TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             UserFull result = null;
             switch (constructor) {
-                case 0x8c72ea81:
+                case 0xf8d32aed:
                     result = new TL_userFull();
+                    break;
+                case 0xec6d41e3:
+                    result = new TL_userFull_layer150_rev2();
+                    break;
+                case 0xc4b1fc3f:
+                    result = new TL_userFull_layer150();
+                    break;
+                case 0x8c72ea81:
+                    result = new TL_userFull_layer143();
                     break;
                 case 0xcf366521:
                     result = new TL_userFull_layer139();
@@ -42511,6 +46922,395 @@ public class TLRPC {
     }
 
     public static class TL_userFull extends UserFull {
+        public static int constructor = 0xf8d32aed;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            blocked = (flags & 1) != 0;
+            phone_calls_available = (flags & 16) != 0;
+            phone_calls_private = (flags & 32) != 0;
+            can_pin_message = (flags & 128) != 0;
+            has_scheduled = (flags & 4096) != 0;
+            video_calls_available = (flags & 8192) != 0;
+            voice_messages_forbidden = (flags & 1048576) != 0;
+            translations_disabled = (flags & 8388608) != 0;
+            id = stream.readInt64(exception);
+            if ((flags & 2) != 0) {
+                about = stream.readString(exception);
+            }
+            settings = TL_peerSettings.TLdeserialize(stream, stream.readInt32(exception), exception);
+            if ((flags & 2097152) != 0) {
+                personal_photo = Photo.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 4) != 0) {
+                profile_photo = Photo.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 4194304) != 0) {
+                fallback_photo = Photo.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            notify_settings = PeerNotifySettings.TLdeserialize(stream, stream.readInt32(exception), exception);
+            if ((flags & 8) != 0) {
+                bot_info = BotInfo.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 64) != 0) {
+                pinned_msg_id = stream.readInt32(exception);
+            }
+            common_chats_count = stream.readInt32(exception);
+            if ((flags & 2048) != 0) {
+                folder_id = stream.readInt32(exception);
+            }
+            if ((flags & 16384) != 0) {
+                ttl_period = stream.readInt32(exception);
+            }
+            if ((flags & 32768) != 0) {
+                theme_emoticon = stream.readString(exception);
+            }
+            if ((flags & 65536) != 0) {
+                private_forward_name = stream.readString(exception);
+            }
+            if ((flags & 131072) != 0) {
+                bot_group_admin_rights = TL_chatAdminRights.TLdeserialize(stream, stream.readInt32(exception),
+                        exception);
+            }
+            if ((flags & 262144) != 0) {
+                bot_broadcast_admin_rights = TL_chatAdminRights.TLdeserialize(stream, stream.readInt32(exception),
+                        exception);
+            }
+            if ((flags & 524288) != 0) {
+                int magic = stream.readInt32(exception);
+                if (magic != 0x1cb5c415) {
+                    if (exception) {
+                        throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                    }
+                    return;
+                }
+                int count = stream.readInt32(exception);
+                for (int a = 0; a < count; a++) {
+                    TL_premiumGiftOption object = TL_premiumGiftOption.TLdeserialize(stream,
+                            stream.readInt32(exception), exception);
+                    if (object == null) {
+                        return;
+                    }
+                    premium_gifts.add(object);
+                }
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = blocked ? (flags | 1) : (flags & ~1);
+            flags = phone_calls_available ? (flags | 16) : (flags & ~16);
+            flags = phone_calls_private ? (flags | 32) : (flags & ~32);
+            flags = can_pin_message ? (flags | 128) : (flags & ~128);
+            flags = has_scheduled ? (flags | 4096) : (flags & ~4096);
+            flags = video_calls_available ? (flags | 8192) : (flags & ~8192);
+            flags = voice_messages_forbidden ? (flags | 1048576) : (flags & ~1048576);
+            flags = translations_disabled ? (flags | 8388608) : (flags & ~8388608);
+            stream.writeInt32(flags);
+            stream.writeInt64(id);
+            if ((flags & 2) != 0) {
+                stream.writeString(about);
+            }
+            settings.serializeToStream(stream);
+            if ((flags & 2097152) != 0) {
+                personal_photo.serializeToStream(stream);
+            }
+            if ((flags & 4) != 0) {
+                profile_photo.serializeToStream(stream);
+            }
+            if ((flags & 4194304) != 0) {
+                fallback_photo.serializeToStream(stream);
+            }
+            notify_settings.serializeToStream(stream);
+            if ((flags & 8) != 0) {
+                bot_info.serializeToStream(stream);
+            }
+            if ((flags & 64) != 0) {
+                stream.writeInt32(pinned_msg_id);
+            }
+            stream.writeInt32(common_chats_count);
+            if ((flags & 2048) != 0) {
+                stream.writeInt32(folder_id);
+            }
+            if ((flags & 16384) != 0) {
+                stream.writeInt32(ttl_period);
+            }
+            if ((flags & 32768) != 0) {
+                stream.writeString(theme_emoticon);
+            }
+            if ((flags & 65536) != 0) {
+                stream.writeString(private_forward_name);
+            }
+            if ((flags & 131072) != 0) {
+                bot_group_admin_rights.serializeToStream(stream);
+            }
+            if ((flags & 262144) != 0) {
+                bot_broadcast_admin_rights.serializeToStream(stream);
+            }
+            if ((flags & 524288) != 0) {
+                stream.writeInt32(0x1cb5c415);
+                int count = premium_gifts.size();
+                stream.writeInt32(count);
+                for (int a = 0; a < count; a++) {
+                    premium_gifts.get(a).serializeToStream(stream);
+                }
+            }
+        }
+    }
+
+    public static class TL_userFull_layer150_rev2 extends UserFull {
+        public static int constructor = 0xec6d41e3;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            blocked = (flags & 1) != 0;
+            phone_calls_available = (flags & 16) != 0;
+            phone_calls_private = (flags & 32) != 0;
+            can_pin_message = (flags & 128) != 0;
+            has_scheduled = (flags & 4096) != 0;
+            video_calls_available = (flags & 8192) != 0;
+            voice_messages_forbidden = (flags & 1048576) != 0;
+            id = stream.readInt64(exception);
+            if ((flags & 2) != 0) {
+                about = stream.readString(exception);
+            }
+            settings = TL_peerSettings.TLdeserialize(stream, stream.readInt32(exception), exception);
+            if ((flags & 2097152) != 0) {
+                personal_photo = Photo.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 4) != 0) {
+                profile_photo = Photo.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            notify_settings = PeerNotifySettings.TLdeserialize(stream, stream.readInt32(exception), exception);
+            if ((flags & 8) != 0) {
+                bot_info = BotInfo.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 64) != 0) {
+                pinned_msg_id = stream.readInt32(exception);
+            }
+            common_chats_count = stream.readInt32(exception);
+            if ((flags & 2048) != 0) {
+                folder_id = stream.readInt32(exception);
+            }
+            if ((flags & 16384) != 0) {
+                ttl_period = stream.readInt32(exception);
+            }
+            if ((flags & 32768) != 0) {
+                theme_emoticon = stream.readString(exception);
+            }
+            if ((flags & 65536) != 0) {
+                private_forward_name = stream.readString(exception);
+            }
+            if ((flags & 131072) != 0) {
+                bot_group_admin_rights = TL_chatAdminRights.TLdeserialize(stream, stream.readInt32(exception),
+                        exception);
+            }
+            if ((flags & 262144) != 0) {
+                bot_broadcast_admin_rights = TL_chatAdminRights.TLdeserialize(stream, stream.readInt32(exception),
+                        exception);
+            }
+            if ((flags & 524288) != 0) {
+                int magic = stream.readInt32(exception);
+                if (magic != 0x1cb5c415) {
+                    if (exception) {
+                        throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                    }
+                    return;
+                }
+                int count = stream.readInt32(exception);
+                for (int a = 0; a < count; a++) {
+                    TL_premiumGiftOption object = TL_premiumGiftOption.TLdeserialize(stream,
+                            stream.readInt32(exception), exception);
+                    if (object == null) {
+                        return;
+                    }
+                    premium_gifts.add(object);
+                }
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = blocked ? (flags | 1) : (flags & ~1);
+            flags = phone_calls_available ? (flags | 16) : (flags &~ 16);
+            flags = phone_calls_private ? (flags | 32) : (flags &~ 32);
+            flags = can_pin_message ? (flags | 128) : (flags &~ 128);
+            flags = has_scheduled ? (flags | 4096) : (flags &~ 4096);
+            flags = video_calls_available ? (flags | 8192) : (flags &~ 8192);
+            flags = voice_messages_forbidden ? (flags | 1048576) : (flags & ~1048576);
+            stream.writeInt32(flags);
+            stream.writeInt64(id);
+            if ((flags & 2) != 0) {
+                stream.writeString(about);
+            }
+            settings.serializeToStream(stream);
+            if ((flags & 2097152) != 0) {
+                personal_photo.serializeToStream(stream);
+            }
+            if ((flags & 4) != 0) {
+                profile_photo.serializeToStream(stream);
+            }
+            notify_settings.serializeToStream(stream);
+            if ((flags & 8) != 0) {
+                bot_info.serializeToStream(stream);
+            }
+            if ((flags & 64) != 0) {
+                stream.writeInt32(pinned_msg_id);
+            }
+            stream.writeInt32(common_chats_count);
+            if ((flags & 2048) != 0) {
+                stream.writeInt32(folder_id);
+            }
+            if ((flags & 16384) != 0) {
+                stream.writeInt32(ttl_period);
+            }
+            if ((flags & 32768) != 0) {
+                stream.writeString(theme_emoticon);
+            }
+            if ((flags & 65536) != 0) {
+                stream.writeString(private_forward_name);
+            }
+            if ((flags & 131072) != 0) {
+                bot_group_admin_rights.serializeToStream(stream);
+            }
+            if ((flags & 262144) != 0) {
+                bot_broadcast_admin_rights.serializeToStream(stream);
+            }
+            if ((flags & 524288) != 0) {
+                stream.writeInt32(0x1cb5c415);
+                int count = premium_gifts.size();
+                stream.writeInt32(count);
+                for (int a = 0; a < count; a++) {
+                    premium_gifts.get(a).serializeToStream(stream);
+                }
+            }
+        }
+    }
+
+    public static class TL_userFull_layer150 extends UserFull {
+        public static int constructor = 0xc4b1fc3f;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            blocked = (flags & 1) != 0;
+            phone_calls_available = (flags & 16) != 0;
+            phone_calls_private = (flags & 32) != 0;
+            can_pin_message = (flags & 128) != 0;
+            has_scheduled = (flags & 4096) != 0;
+            video_calls_available = (flags & 8192) != 0;
+            voice_messages_forbidden = (flags & 1048576) != 0;
+            id = stream.readInt64(exception);
+            if ((flags & 2) != 0) {
+                about = stream.readString(exception);
+            }
+            settings = TL_peerSettings.TLdeserialize(stream, stream.readInt32(exception), exception);
+            if ((flags & 4) != 0) {
+                profile_photo = Photo.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            notify_settings = PeerNotifySettings.TLdeserialize(stream, stream.readInt32(exception), exception);
+            if ((flags & 8) != 0) {
+                bot_info = BotInfo.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 64) != 0) {
+                pinned_msg_id = stream.readInt32(exception);
+            }
+            common_chats_count = stream.readInt32(exception);
+            if ((flags & 2048) != 0) {
+                folder_id = stream.readInt32(exception);
+            }
+            if ((flags & 16384) != 0) {
+                ttl_period = stream.readInt32(exception);
+            }
+            if ((flags & 32768) != 0) {
+                theme_emoticon = stream.readString(exception);
+            }
+            if ((flags & 65536) != 0) {
+                private_forward_name = stream.readString(exception);
+            }
+            if ((flags & 131072) != 0) {
+                bot_group_admin_rights = TL_chatAdminRights.TLdeserialize(stream, stream.readInt32(exception),
+                        exception);
+            }
+            if ((flags & 262144) != 0) {
+                bot_broadcast_admin_rights = TL_chatAdminRights.TLdeserialize(stream, stream.readInt32(exception),
+                        exception);
+            }
+            if ((flags & 524288) != 0) {
+                int magic = stream.readInt32(exception);
+                if (magic != 0x1cb5c415) {
+                    if (exception) {
+                        throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                    }
+                    return;
+                }
+                int count = stream.readInt32(exception);
+                for (int a = 0; a < count; a++) {
+                    TL_premiumGiftOption object = TL_premiumGiftOption.TLdeserialize(stream,
+                            stream.readInt32(exception), exception);
+                    if (object == null) {
+                        return;
+                    }
+                    premium_gifts.add(object);
+                }
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = blocked ? (flags | 1) : (flags &~ 1);
+            flags = phone_calls_available ? (flags | 16) : (flags &~ 16);
+            flags = phone_calls_private ? (flags | 32) : (flags &~ 32);
+            flags = can_pin_message ? (flags | 128) : (flags &~ 128);
+            flags = has_scheduled ? (flags | 4096) : (flags &~ 4096);
+            flags = video_calls_available ? (flags | 8192) : (flags &~ 8192);
+            flags = voice_messages_forbidden ? (flags | 1048576) : (flags & ~1048576);
+            stream.writeInt32(flags);
+            stream.writeInt64(id);
+            if ((flags & 2) != 0) {
+                stream.writeString(about);
+            }
+            settings.serializeToStream(stream);
+            if ((flags & 4) != 0) {
+                profile_photo.serializeToStream(stream);
+            }
+            notify_settings.serializeToStream(stream);
+            if ((flags & 8) != 0) {
+                bot_info.serializeToStream(stream);
+            }
+            if ((flags & 64) != 0) {
+                stream.writeInt32(pinned_msg_id);
+            }
+            stream.writeInt32(common_chats_count);
+            if ((flags & 2048) != 0) {
+                stream.writeInt32(folder_id);
+            }
+            if ((flags & 16384) != 0) {
+                stream.writeInt32(ttl_period);
+            }
+            if ((flags & 32768) != 0) {
+                stream.writeString(theme_emoticon);
+            }
+            if ((flags & 65536) != 0) {
+                stream.writeString(private_forward_name);
+            }
+            if ((flags & 131072) != 0) {
+                bot_group_admin_rights.serializeToStream(stream);
+            }
+            if ((flags & 262144) != 0) {
+                bot_broadcast_admin_rights.serializeToStream(stream);
+            }
+            if ((flags & 524288) != 0) {
+                stream.writeInt32(0x1cb5c415);
+                int count = premium_gifts.size();
+                stream.writeInt32(count);
+                for (int a = 0; a < count; a++) {
+                    premium_gifts.get(a).serializeToStream(stream);
+                }
+            }
+        }
+    }
+
+    public static class TL_userFull_layer143 extends TL_userFull {
         public static int constructor = 0x8c72ea81;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
@@ -42561,10 +47361,10 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = blocked ? (flags | 1) : (flags & ~1);
-            flags = phone_calls_available ? (flags | 16) : (flags & ~16);
-            flags = phone_calls_private ? (flags | 32) : (flags & ~32);
-            flags = can_pin_message ? (flags | 128) : (flags & ~128);
+            flags = blocked ? (flags | 1) : (flags &~ 1);
+            flags = phone_calls_available ? (flags | 16) : (flags &~ 16);
+            flags = phone_calls_private ? (flags | 32) : (flags &~ 32);
+            flags = can_pin_message ? (flags | 128) : (flags &~ 128);
             flags = has_scheduled ? (flags | 4096) : (flags & ~4096);
             flags = video_calls_available ? (flags | 8192) : (flags & ~8192);
             stream.writeInt32(flags);
@@ -42652,8 +47452,8 @@ public class TLRPC {
             flags = phone_calls_available ? (flags | 16) : (flags &~ 16);
             flags = phone_calls_private ? (flags | 32) : (flags &~ 32);
             flags = can_pin_message ? (flags | 128) : (flags &~ 128);
-            flags = has_scheduled ? (flags | 4096) : (flags &~ 4096);
-            flags = video_calls_available ? (flags | 8192) : (flags &~ 8192);
+            flags = has_scheduled ? (flags | 4096) : (flags & ~4096);
+            flags = video_calls_available ? (flags | 8192) : (flags & ~8192);
             stream.writeInt32(flags);
             stream.writeInt64(id);
             if ((flags & 2) != 0) {
@@ -42852,10 +47652,10 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = blocked ? (flags | 1) : (flags &~ 1);
-            flags = phone_calls_available ? (flags | 16) : (flags &~ 16);
-            flags = phone_calls_private ? (flags | 32) : (flags &~ 32);
-            flags = can_pin_message ? (flags | 128) : (flags &~ 128);
+            flags = blocked ? (flags | 1) : (flags & ~1);
+            flags = phone_calls_available ? (flags | 16) : (flags & ~16);
+            flags = phone_calls_private ? (flags | 32) : (flags & ~32);
+            flags = can_pin_message ? (flags | 128) : (flags & ~128);
             stream.writeInt32(flags);
             user.serializeToStream(stream);
             if ((flags & 2) != 0) {
@@ -42914,12 +47714,12 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = blocked ? (flags | 1) : (flags &~ 1);
-            flags = phone_calls_available ? (flags | 16) : (flags &~ 16);
-            flags = phone_calls_private ? (flags | 32) : (flags &~ 32);
-            flags = can_pin_message ? (flags | 128) : (flags &~ 128);
-            flags = has_scheduled ? (flags | 4096) : (flags &~ 4096);
-            flags = video_calls_available ? (flags | 8192) : (flags &~ 8192);
+            flags = blocked ? (flags | 1) : (flags & ~1);
+            flags = phone_calls_available ? (flags | 16) : (flags & ~16);
+            flags = phone_calls_private ? (flags | 32) : (flags & ~32);
+            flags = can_pin_message ? (flags | 128) : (flags & ~128);
+            flags = has_scheduled ? (flags | 4096) : (flags & ~4096);
+            flags = video_calls_available ? (flags | 8192) : (flags & ~8192);
             stream.writeInt32(flags);
             user.serializeToStream(stream);
             if ((flags & 2) != 0) {
@@ -42981,11 +47781,11 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = blocked ? (flags | 1) : (flags &~ 1);
-            flags = phone_calls_available ? (flags | 16) : (flags &~ 16);
-            flags = phone_calls_private ? (flags | 32) : (flags &~ 32);
-            flags = can_pin_message ? (flags | 128) : (flags &~ 128);
-            flags = has_scheduled ? (flags | 4096) : (flags &~ 4096);
+            flags = blocked ? (flags | 1) : (flags & ~1);
+            flags = phone_calls_available ? (flags | 16) : (flags & ~16);
+            flags = phone_calls_private ? (flags | 32) : (flags & ~32);
+            flags = can_pin_message ? (flags | 128) : (flags & ~128);
+            flags = has_scheduled ? (flags | 4096) : (flags & ~4096);
             stream.writeInt32(flags);
             user.serializeToStream(stream);
             if ((flags & 2) != 0) {
@@ -43629,16 +48429,85 @@ public class TLRPC {
         }
     }
 
+    public static abstract class EmojiStatus extends TLObject {
+
+        public static EmojiStatus TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+            EmojiStatus result = null;
+            switch (constructor) {
+                case 0x2de11aae:
+                    result = new TL_emojiStatusEmpty();
+                    break;
+                case 0x929b619d:
+                    result = new TL_emojiStatus();
+                    break;
+                case 0xfa30a8c7:
+                    result = new TL_emojiStatusUntil();
+                    break;
+            }
+            if (result == null && exception) {
+                throw new RuntimeException(String.format("can't parse magic %x in EmojiStatus", constructor));
+            }
+            if (result != null) {
+                result.readParams(stream, exception);
+            }
+            return result;
+        }
+    }
+
+    public static class TL_emojiStatusEmpty extends EmojiStatus {
+        public static int constructor = 0x2de11aae;
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
+    public static class TL_emojiStatus extends EmojiStatus {
+        public static int constructor = 0x929b619d;
+
+        public long document_id;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            document_id = stream.readInt64(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt64(document_id);
+        }
+    }
+
+    public static class TL_emojiStatusUntil extends EmojiStatus {
+        public static int constructor = 0xfa30a8c7;
+
+        public long document_id;
+        public int until;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            document_id = stream.readInt64(exception);
+            until = stream.readInt32(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt64(document_id);
+            stream.writeInt32(until);
+        }
+    }
+
+
     public static class TL_inputEncryptedChat extends TLObject {
         public static int constructor = 0xf141b5e1;
 
         public int chat_id;
         public long access_hash;
 
-        public static TL_inputEncryptedChat TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+        public static TL_inputEncryptedChat TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
             if (TL_inputEncryptedChat.constructor != constructor) {
                 if (exception) {
-                    throw new RuntimeException(String.format("can't parse magic %x in TL_inputEncryptedChat", constructor));
+                    throw new RuntimeException(
+                            String.format("can't parse magic %x in TL_inputEncryptedChat", constructor));
                 } else {
                     return null;
                 }
@@ -43671,7 +48540,7 @@ public class TLRPC {
                 case 0x1ca48f57:
                     result = new TL_inputChatPhotoEmpty();
                     break;
-                case 0xc642724e:
+                case 0xbdcdaec0:
                     result = new TL_inputChatUploadedPhoto();
                     break;
             }
@@ -43710,12 +48579,13 @@ public class TLRPC {
     }
 
     public static class TL_inputChatUploadedPhoto extends InputChatPhoto {
-        public static int constructor = 0xc642724e;
+        public static int constructor = 0xbdcdaec0;
 
         public int flags;
         public InputFile file;
         public InputFile video;
         public double video_start_ts;
+        public VideoSize video_emoji_markup;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
             flags = stream.readInt32(exception);
@@ -43727,6 +48597,9 @@ public class TLRPC {
             }
             if ((flags & 4) != 0) {
                 video_start_ts = stream.readDouble(exception);
+            }
+            if ((flags & 8) != 0) {
+                video_emoji_markup = VideoSize.TLdeserialize(0, 0, stream, stream.readInt32(exception), exception);
             }
         }
 
@@ -43741,6 +48614,9 @@ public class TLRPC {
             }
             if ((flags & 4) != 0) {
                 stream.writeDouble(video_start_ts);
+            }
+            if ((flags & 8) != 0) {
+                video_emoji_markup.serializeToStream(stream);
             }
         }
     }
@@ -43874,7 +48750,7 @@ public class TLRPC {
 
         public int flags;
         public int count;
-        public ArrayList<TL_messagePeerReaction> reactions = new ArrayList<>();
+        public ArrayList<MessagePeerReaction> reactions = new ArrayList<>();
         public ArrayList<Chat> chats = new ArrayList<>();
         public ArrayList<User> users = new ArrayList<>();
         public String next_offset;
@@ -43904,7 +48780,7 @@ public class TLRPC {
             }
             int count = stream.readInt32(exception);
             for (int a = 0; a < count; a++) {
-                TL_messagePeerReaction object = MessagePeerReaction.TLdeserialize(stream, stream.readInt32(exception),
+                MessagePeerReaction object = MessagePeerReaction.TLdeserialize(stream, stream.readInt32(exception),
                         exception);
                 if (object == null) {
                     return;
@@ -44985,9 +49861,9 @@ public class TLRPC {
     }
 
     public static class TL_fileHash extends TLObject {
-        public static int constructor = 0x6242c773;
+        public static int constructor = 0xf39b035c;
 
-        public int offset;
+        public long offset;
         public int limit;
         public byte[] hash;
 
@@ -45005,14 +49881,14 @@ public class TLRPC {
         }
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
-            offset = stream.readInt32(exception);
+            offset = stream.readInt64(exception);
             limit = stream.readInt32(exception);
             hash = stream.readByteArray(exception);
         }
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            stream.writeInt32(offset);
+            stream.writeInt64(offset);
             stream.writeInt32(limit);
             stream.writeByteArray(hash);
         }
@@ -45571,6 +50447,166 @@ public class TLRPC {
         }
     }
 
+
+
+    public static abstract class Reaction extends TLObject {
+
+        public static Reaction TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+            Reaction result = null;
+            switch (constructor) {
+                case 0x8935fc73:
+                    result = new TL_reactionCustomEmoji();
+                    break;
+                case 0x79f5d419:
+                    result = new TL_reactionEmpty();
+                    break;
+                case 0x1b2286b8:
+                    result = new TL_reactionEmoji();
+                    break;
+            }
+            if (result == null && exception) {
+                throw new RuntimeException(String.format("can't parse magic %x in Reaction", constructor));
+            }
+            if (result != null) {
+                result.readParams(stream, exception);
+            }
+            return result;
+        }
+
+        public boolean equals(@Nullable Reaction other) {
+            if (other == null)
+                return false;
+            if (this instanceof TL_reactionEmpty && other instanceof TL_reactionEmpty)
+                return true;
+            if (this instanceof TL_reactionEmoji && other instanceof TL_reactionEmoji)
+                return ((TL_reactionEmoji) this).emoticon == ((TL_reactionEmoji) other).emoticon;
+            ;
+            if (this instanceof TL_reactionCustomEmoji && other instanceof TL_reactionCustomEmoji)
+                return ((TL_reactionCustomEmoji) this).document_id == ((TL_reactionCustomEmoji) other).document_id;
+            return false;
+        }
+    }
+
+    public static class TL_reactionCustomEmoji extends Reaction {
+        public static int constructor = 0x8935fc73;
+
+        public long document_id;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            document_id = stream.readInt64(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt64(document_id);
+        }
+    }
+
+    public static class TL_reactionEmpty extends Reaction {
+        public static int constructor = 0x79f5d419;
+
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
+    public static class TL_reactionEmoji extends Reaction {
+        public static int constructor = 0x1b2286b8;
+
+        public String emoticon;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            emoticon = stream.readString(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeString(emoticon);
+        }
+    }
+
+    public static class TL_messages_getEmojiGroups extends TLObject {
+        public static int constructor = 0x7488ce5b;
+
+        public int hash;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return messages_EmojiGroups.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(hash);
+        }
+    }
+
+    public static class TL_messages_getEmojiProfilePhotoGroups extends TLObject {
+        public static int constructor = 0x21a548f3;
+
+        public int hash;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return messages_EmojiGroups.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(hash);
+        }
+    }
+
+    public static class TL_messages_getEmojiStatusGroups extends TLObject {
+        public static int constructor = 0x2ecd56cd;
+
+        public int hash;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return messages_EmojiGroups.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(hash);
+        }
+    }
+
+    public static class TL_messages_searchCustomEmoji extends TLObject {
+        public static int constructor = 0x2c11c0d7;
+
+        public String emoticon;
+        public long hash;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return EmojiList.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeString(emoticon);
+            stream.writeInt64(hash);
+        }
+    }
+
+    public static class TL_messages_togglePeerTranslations extends TLObject {
+        public static int constructor = 0xe47cb579;
+
+        public int flags;
+        public boolean disabled;
+        public InputPeer peer;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Bool.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = disabled ? (flags | 1) : (flags & ~1);
+            stream.writeInt32(flags);
+            peer.serializeToStream(stream);
+        }
+    }
+
     public static class TL_auth_sendCode extends TLObject {
         public static int constructor = 0xa677244f;
 
@@ -45613,7 +50649,7 @@ public class TLRPC {
         }
     }
 
-    public static class TL_auth_signIn extends TLObject {
+    public static class TL_auth_signInOld extends TLObject {
         public static int constructor = 0xbcd51581;
 
         public String phone_number;
@@ -45629,6 +50665,33 @@ public class TLRPC {
             stream.writeString(phone_number);
             stream.writeString(phone_code_hash);
             stream.writeString(phone_code);
+        }
+    }
+
+    public static class TL_auth_signIn extends TLObject {
+        public static int constructor = 0x8d52a951;
+
+        public int flags;
+        public String phone_number;
+        public String phone_code_hash;
+        public String phone_code;
+        public EmailVerification email_verification;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return auth_Authorization.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(flags);
+            stream.writeString(phone_number);
+            stream.writeString(phone_code_hash);
+            if ((flags & 1) != 0) {
+                stream.writeString(phone_code);
+            }
+            if ((flags & 2) != 0) {
+                email_verification.serializeToStream(stream);
+            }
         }
     }
 
@@ -45756,6 +50819,33 @@ public class TLRPC {
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
             stream.writeString(code);
+        }
+    }
+
+    public static class TL_auth_requestFirebaseSms extends TLObject {
+        public static int constructor = 0x89464b50;
+
+        public int flags;
+        public String phone_number;
+        public String phone_code_hash;
+        public String safety_net_token;
+        public String ios_push_secret;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Bool.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(flags);
+            stream.writeString(phone_number);
+            stream.writeString(phone_code_hash);
+            if ((flags & 1) != 0) {
+                stream.writeString(safety_net_token);
+            }
+            if ((flags & 2) != 0) {
+                stream.writeString(ios_push_secret);
+            }
         }
     }
 
@@ -46553,6 +51643,19 @@ public class TLRPC {
         }
     }
 
+    public static class TL_help_getPremiumPromo extends TLObject {
+        public static int constructor = 0xb81b93d4;
+
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return TL_help_premiumPromo.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
     public static class TL_help_getUserInfo extends TLObject {
         public static int constructor = 0x38a08d3;
 
@@ -46959,15 +52062,18 @@ public class TLRPC {
     }
 
     public static class TL_messages_sendMessage extends TLObject {
-        public static int constructor = 0xd9d75a4;
+        public static int constructor = 0x1cc20387;
 
         public int flags;
         public boolean no_webpage;
         public boolean silent;
         public boolean background;
         public boolean clear_draft;
+        public boolean noforwards;
+        public boolean update_stickersets_order;
         public InputPeer peer;
         public int reply_to_msg_id;
+        public int top_msg_id;
         public String message;
         public long random_id;
         public ReplyMarkup reply_markup;
@@ -46985,10 +52091,15 @@ public class TLRPC {
             flags = silent ? (flags | 32) : (flags &~ 32);
             flags = background ? (flags | 64) : (flags &~ 64);
             flags = clear_draft ? (flags | 128) : (flags &~ 128);
+            flags = noforwards ? (flags | 16384) : (flags & ~16384);
+            flags = update_stickersets_order ? (flags | 32768) : (flags & ~32768);
             stream.writeInt32(flags);
             peer.serializeToStream(stream);
             if ((flags & 1) != 0) {
                 stream.writeInt32(reply_to_msg_id);
+            }
+            if ((flags & 512) != 0) {
+                stream.writeInt32(top_msg_id);
             }
             stream.writeString(message);
             stream.writeInt64(random_id);
@@ -47013,14 +52124,17 @@ public class TLRPC {
     }
 
     public static class TL_messages_sendMedia extends TLObject {
-        public static int constructor = 0xe25ff8e0;
+        public static int constructor = 0x7547c966;
 
         public int flags;
         public boolean silent;
         public boolean background;
         public boolean clear_draft;
+        public boolean noforwards;
+        public boolean update_stickersets_order;
         public InputPeer peer;
         public int reply_to_msg_id;
+        public int top_msg_id;
         public InputMedia media;
         public String message;
         public long random_id;
@@ -47038,10 +52152,15 @@ public class TLRPC {
             flags = silent ? (flags | 32) : (flags &~ 32);
             flags = background ? (flags | 64) : (flags &~ 64);
             flags = clear_draft ? (flags | 128) : (flags &~ 128);
+            flags = noforwards ? (flags | 16384) : (flags & ~16384);
+            flags = update_stickersets_order ? (flags | 32768) : (flags & ~32768);
             stream.writeInt32(flags);
             peer.serializeToStream(stream);
             if ((flags & 1) != 0) {
                 stream.writeInt32(reply_to_msg_id);
+            }
+            if ((flags & 512) != 0) {
+                stream.writeInt32(top_msg_id);
             }
             media.serializeToStream(stream);
             stream.writeString(message);
@@ -47067,7 +52186,7 @@ public class TLRPC {
     }
 
     public static class TL_messages_forwardMessages extends TLObject {
-        public static int constructor = 0xcc30290b;
+        public static int constructor = 0xc661bbc4;
 
         public int flags;
         public boolean silent;
@@ -47075,10 +52194,12 @@ public class TLRPC {
         public boolean with_my_score;
         public boolean drop_author;
         public boolean drop_media_captions;
+        public boolean noforwards;
         public InputPeer from_peer;
         public ArrayList<Integer> id = new ArrayList<>();
         public ArrayList<Long> random_id = new ArrayList<>();
         public InputPeer to_peer;
+        public int top_msg_id;
         public int schedule_date;
         public InputPeer send_as;
 
@@ -47093,6 +52214,7 @@ public class TLRPC {
             flags = with_my_score ? (flags | 256) : (flags &~ 256);
             flags = drop_author ? (flags | 2048) : (flags &~ 2048);
             flags = drop_media_captions ? (flags | 4096) : (flags &~ 4096);
+            flags = noforwards ? (flags | 16384) : (flags & ~16384);
             stream.writeInt32(flags);
             from_peer.serializeToStream(stream);
             stream.writeInt32(0x1cb5c415);
@@ -47108,6 +52230,9 @@ public class TLRPC {
                 stream.writeInt64(random_id.get(a));
             }
             to_peer.serializeToStream(stream);
+            if ((flags & 512) != 0) {
+                stream.writeInt32(top_msg_id);
+            }
             if ((flags & 1024) != 0) {
                 stream.writeInt32(schedule_date);
             }
@@ -47283,10 +52408,12 @@ public class TLRPC {
     }
 
     public static class TL_messages_createChat extends TLObject {
-        public static int constructor = 0x9cb126e;
+        public static int constructor = 0x34a818;
 
+        public int flags;
         public ArrayList<InputUser> users = new ArrayList<>();
         public String title;
+        public int ttl_period;
 
         public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
             return Updates.TLdeserialize(stream, constructor, exception);
@@ -47294,6 +52421,7 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+            stream.writeInt32(flags);
             stream.writeInt32(0x1cb5c415);
             int count = users.size();
             stream.writeInt32(count);
@@ -47301,6 +52429,9 @@ public class TLRPC {
                 users.get(a).serializeToStream(stream);
             }
             stream.writeString(title);
+            if ((flags & 1) != 0) {
+                stream.writeInt32(ttl_period);
+            }
         }
     }
 
@@ -47404,12 +52535,14 @@ public class TLRPC {
     }
 
     public static class TL_photos_uploadProfilePhoto extends TLObject {
-        public static int constructor = 0x89f30f69;
+        public static int constructor = 0x93c9a51;
 
         public int flags;
+        public boolean fallback;
         public InputFile file;
         public InputFile video;
         public double video_start_ts;
+        public VideoSize video_emoji_markup;
 
         public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
             return TL_photos_photo.TLdeserialize(stream, constructor, exception);
@@ -47417,6 +52550,7 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+            flags = fallback ? (flags | 8) : (flags & ~8);
             stream.writeInt32(flags);
             if ((flags & 1) != 0) {
                 file.serializeToStream(stream);
@@ -47426,6 +52560,9 @@ public class TLRPC {
             }
             if ((flags & 4) != 0) {
                 stream.writeDouble(video_start_ts);
+            }
+            if ((flags & 16) != 0) {
+                video_emoji_markup.serializeToStream(stream);
             }
         }
     }
@@ -47456,13 +52593,13 @@ public class TLRPC {
     }
 
     public static class TL_upload_getFile extends TLObject {
-        public static int constructor = 0xb15a9afc;
+        public static int constructor = 0xbe5335be;
 
         public int flags;
         public boolean precise;
         public boolean cdn_supported;
         public InputFileLocation location;
-        public int offset;
+        public long offset;
         public int limit;
 
         public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
@@ -47475,7 +52612,7 @@ public class TLRPC {
             flags = cdn_supported ? (flags | 2) : (flags &~ 2);
             stream.writeInt32(flags);
             location.serializeToStream(stream);
-            stream.writeInt32(offset);
+            stream.writeInt64(offset);
             stream.writeInt32(limit);
         }
     }
@@ -48306,8 +53443,9 @@ public class TLRPC {
     }
 
     public static class TL_account_sendVerifyEmailCode extends TLObject {
-        public static int constructor = 0x7011509f;
+        public static int constructor = 0x98e037bb;
 
+        public EmailVerifyPurpose purpose;
         public String email;
 
         public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
@@ -48316,24 +53454,25 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+            purpose.serializeToStream(stream);
             stream.writeString(email);
         }
     }
 
     public static class TL_account_verifyEmail extends TLObject {
-        public static int constructor = 0xecba39db;
+        public static int constructor = 0x32da4cf;
 
-        public String email;
-        public String code;
+        public EmailVerifyPurpose purpose;
+        public EmailVerification verification;
 
         public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
-            return Bool.TLdeserialize(stream, constructor, exception);
+            return account_EmailVerified.TLdeserialize(stream, constructor, exception);
         }
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            stream.writeString(email);
-            stream.writeString(code);
+            purpose.serializeToStream(stream);
+            verification.serializeToStream(stream);
         }
     }
 
@@ -48709,6 +53848,64 @@ public class TLRPC {
         }
     }
 
+    public static class TL_account_updateEmojiStatus extends TLObject {
+        public static int constructor = 0xfbd3de6b;
+
+        public EmojiStatus emoji_status;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Bool.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            emoji_status.serializeToStream(stream);
+        }
+    }
+
+    public static class TL_account_getDefaultEmojiStatuses extends TLObject {
+        public static int constructor = 0xd6753386;
+
+        public long hash;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return account_EmojiStatuses.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt64(hash);
+        }
+    }
+
+    public static class TL_account_getRecentEmojiStatuses extends TLObject {
+        public static int constructor = 0xf578105;
+
+        public long hash;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return account_EmojiStatuses.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt64(hash);
+        }
+    }
+
+    public static class TL_account_clearRecentEmojiStatuses extends TLObject {
+        public static int constructor = 0x18201aae;
+
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Bool.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
     public static class TL_account_updateDeviceLocked extends TLObject {
         public static int constructor = 0x38df3532;
 
@@ -49021,9 +54218,10 @@ public class TLRPC {
     }
 
     public static class TL_messages_getStickerSet extends TLObject {
-        public static int constructor = 0x2619a90e;
+        public static int constructor = 0xc8a0ec74;
 
         public InputStickerSet stickerset;
+        public int hash;
 
         public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
             return TL_messages_stickerSet.TLdeserialize(stream, constructor, exception);
@@ -49032,6 +54230,7 @@ public class TLRPC {
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
             stickerset.serializeToStream(stream);
+            stream.writeInt32(hash);
         }
     }
 
@@ -49172,7 +54371,7 @@ public class TLRPC {
     }
 
     public static class TL_messages_sendInlineBotResult extends TLObject {
-        public static int constructor = 0x7aa11297;
+        public static int constructor = 0xd3fbdccb;
 
         public int flags;
         public boolean silent;
@@ -49181,6 +54380,7 @@ public class TLRPC {
         public boolean hide_via;
         public InputPeer peer;
         public int reply_to_msg_id;
+        public int top_msg_id;
         public long random_id;
         public long query_id;
         public String id;
@@ -49201,6 +54401,9 @@ public class TLRPC {
             peer.serializeToStream(stream);
             if ((flags & 1) != 0) {
                 stream.writeInt32(reply_to_msg_id);
+            }
+            if ((flags & 512) != 0) {
+                stream.writeInt32(top_msg_id);
             }
             stream.writeInt64(random_id);
             stream.writeInt64(query_id);
@@ -49356,11 +54559,12 @@ public class TLRPC {
     }
 
     public static class TL_messages_saveDraft extends TLObject {
-        public static int constructor = 0xbc39e14b;
+        public static int constructor = 0xb4331e3f;
 
         public int flags;
         public boolean no_webpage;
         public int reply_to_msg_id;
+        public int top_msg_id;
         public InputPeer peer;
         public String message;
         public ArrayList<MessageEntity> entities = new ArrayList<>();
@@ -49375,6 +54579,9 @@ public class TLRPC {
             stream.writeInt32(flags);
             if ((flags & 1) != 0) {
                 stream.writeInt32(reply_to_msg_id);
+            }
+            if ((flags & 4) != 0) {
+                stream.writeInt32(top_msg_id);
             }
             peer.serializeToStream(stream);
             stream.writeString(message);
@@ -49499,6 +54706,7 @@ public class TLRPC {
 
         public int flags;
         public boolean masks;
+        public boolean emojis;
         public long offset_id;
         public int limit;
 
@@ -49509,6 +54717,7 @@ public class TLRPC {
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
             flags = masks ? (flags | 1) : (flags &~ 1);
+            flags = emojis ? (flags | 2) : (flags & ~2);
             stream.writeInt32(flags);
             stream.writeInt64(offset_id);
             stream.writeInt32(limit);
@@ -49827,9 +55036,11 @@ public class TLRPC {
     }
 
     public static class TL_messages_getUnreadMentions extends TLObject {
-        public static int constructor = 0x46578472;
+        public static int constructor = 0xf107e790;
 
+        public int flags;
         public InputPeer peer;
+        public int top_msg_id;
         public int offset_id;
         public int add_offset;
         public int limit;
@@ -49842,7 +55053,11 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+            stream.writeInt32(flags);
             peer.serializeToStream(stream);
+            if ((flags & 1) != 0) {
+                stream.writeInt32(top_msg_id);
+            }
             stream.writeInt32(offset_id);
             stream.writeInt32(add_offset);
             stream.writeInt32(limit);
@@ -49852,9 +55067,11 @@ public class TLRPC {
     }
 
     public static class TL_messages_readMentions extends TLObject {
-        public static int constructor = 0xf0189d3;
+        public static int constructor = 0x36e5bf4d;
 
+        public int flags;
         public InputPeer peer;
+        public int top_msg_id;
 
         public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
             return TL_messages_affectedHistory.TLdeserialize(stream, constructor, exception);
@@ -49862,7 +55079,11 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+            stream.writeInt32(flags);
             peer.serializeToStream(stream);
+            if ((flags & 1) != 0) {
+                stream.writeInt32(top_msg_id);
+            }
         }
     }
 
@@ -49886,14 +55107,17 @@ public class TLRPC {
     }
 
     public static class TL_messages_sendMultiMedia extends TLObject {
-        public static int constructor = 0xf803138f;
+        public static int constructor = 0xb6f11a1c;
 
         public int flags;
         public boolean silent;
         public boolean background;
         public boolean clear_draft;
+        public boolean noforwards;
+        public boolean update_stickersets_order;
         public InputPeer peer;
         public int reply_to_msg_id;
+        public int top_msg_id;
         public ArrayList<TL_inputSingleMedia> multi_media = new ArrayList<>();
         public int schedule_date;
         public InputPeer send_as;
@@ -49907,10 +55131,15 @@ public class TLRPC {
             flags = silent ? (flags | 32) : (flags &~ 32);
             flags = background ? (flags | 64) : (flags &~ 64);
             flags = clear_draft ? (flags | 128) : (flags &~ 128);
+            flags = noforwards ? (flags | 16384) : (flags & ~16384);
+            flags = update_stickersets_order ? (flags | 32768) : (flags & ~32768);
             stream.writeInt32(flags);
             peer.serializeToStream(stream);
             if ((flags & 1) != 0) {
                 stream.writeInt32(reply_to_msg_id);
+            }
+            if ((flags & 512) != 0) {
+                stream.writeInt32(top_msg_id);
             }
             stream.writeInt32(0x1cb5c415);
             int count = multi_media.size();
@@ -50153,9 +55382,11 @@ public class TLRPC {
     }
 
     public static class TL_messages_getSearchCounters extends TLObject {
-        public static int constructor = 0x732eef00;
+        public static int constructor = 0xae7cc1;
 
+        public int flags;
         public InputPeer peer;
+        public int top_msg_id;
         public ArrayList<MessagesFilter> filters = new ArrayList<>();
 
         public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
@@ -50173,7 +55404,11 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+            stream.writeInt32(flags);
             peer.serializeToStream(stream);
+            if ((flags & 1) != 0) {
+                stream.writeInt32(top_msg_id);
+            }
             stream.writeInt32(0x1cb5c415);
             int count = filters.size();
             stream.writeInt32(count);
@@ -50374,13 +55609,14 @@ public class TLRPC {
     }
 
     public static class TL_messages_sendReaction extends TLObject {
-        public static int constructor = 0x25690ce4;
+        public static int constructor = 0xd30d78d4;
 
         public int flags;
         public boolean big;
+        public boolean add_to_recent;
         public InputPeer peer;
         public int msg_id;
-        public String reaction;
+        public ArrayList<Reaction> reaction = new ArrayList<>();
 
         public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
             return Updates.TLdeserialize(stream, constructor, exception);
@@ -50389,27 +55625,47 @@ public class TLRPC {
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
             flags = big ? (flags | 2) : (flags & ~2);
+            flags = add_to_recent ? (flags | 4) : (flags & ~4);
             stream.writeInt32(flags);
             peer.serializeToStream(stream);
             stream.writeInt32(msg_id);
             if ((flags & 1) != 0) {
-                stream.writeString(reaction);
+                stream.writeInt32(0x1cb5c415);
+                int count = reaction.size();
+                stream.writeInt32(count);
+                for (int a = 0; a < count; a++) {
+                    reaction.get(a).serializeToStream(stream);
+                }
             }
         }
     }
 
+    public static class TL_messages_setDefaultReaction extends TLObject {
+        public static int constructor = 0x4f47a016;
+
+        public Reaction reaction;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Bool.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            reaction.serializeToStream(stream);
+        }
+    }
+
     public static class TL_messages_translateText extends TLObject {
-        public static int constructor = 0x24ce6dee;
+        public static int constructor = 0x63183030;
 
         public int flags;
         public InputPeer peer;
-        public int msg_id;
-        public String text;
-        public String from_lang;
+        public ArrayList<Integer> id = new ArrayList<>();
+        public ArrayList<TL_textWithEntities> text = new ArrayList<>();
         public String to_lang;
 
         public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
-            return messages_TranslatedText.TLdeserialize(stream, constructor, exception);
+            return TL_messages_translateResult.TLdeserialize(stream, constructor, exception);
         }
 
         public void serializeToStream(AbstractSerializedData stream) {
@@ -50419,22 +55675,31 @@ public class TLRPC {
                 peer.serializeToStream(stream);
             }
             if ((flags & 1) != 0) {
-                stream.writeInt32(msg_id);
+                stream.writeInt32(0x1cb5c415);
+                int count = id.size();
+                stream.writeInt32(count);
+                for (int a = 0; a < count; a++) {
+                    stream.writeInt32(id.get(a));
+                }
             }
             if ((flags & 2) != 0) {
-                stream.writeString(text);
-            }
-            if ((flags & 4) != 0) {
-                stream.writeString(from_lang);
+                stream.writeInt32(0x1cb5c415);
+                final int count = text.size();
+                stream.writeInt32(count);
+                for (int a = 0; a < count; a++) {
+                    text.get(a).serializeToStream(stream);
+                }
             }
             stream.writeString(to_lang);
         }
     }
 
     public static class TL_messages_getUnreadReactions extends TLObject {
-        public static int constructor = 0xe85bae1a;
+        public static int constructor = 0x3223495b;
 
+        public int flags;
         public InputPeer peer;
+        public int top_msg_id;
         public int offset_id;
         public int add_offset;
         public int limit;
@@ -50447,7 +55712,11 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+            stream.writeInt32(flags);
             peer.serializeToStream(stream);
+            if ((flags & 1) != 0) {
+                stream.writeInt32(top_msg_id);
+            }
             stream.writeInt32(offset_id);
             stream.writeInt32(add_offset);
             stream.writeInt32(limit);
@@ -50457,9 +55726,11 @@ public class TLRPC {
     }
 
     public static class TL_messages_readReactions extends TLObject {
-        public static int constructor = 0x82e251d7;
+        public static int constructor = 0x54aa7f8e;
 
+        public int flags;
         public InputPeer peer;
+        public int top_msg_id;
 
         public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
             return TL_messages_affectedHistory.TLdeserialize(stream, constructor, exception);
@@ -50467,7 +55738,11 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+            stream.writeInt32(flags);
             peer.serializeToStream(stream);
+            if ((flags & 1) != 0) {
+                stream.writeInt32(top_msg_id);
+            }
         }
     }
 
@@ -50515,12 +55790,12 @@ public class TLRPC {
     }
 
     public static class TL_messages_getMessageReactionsList extends TLObject {
-        public static int constructor = 0xe0ee6b77;
+        public static int constructor = 0x461b3f48;
 
         public int flags;
         public InputPeer peer;
         public int id;
-        public String reaction;
+        public Reaction reaction;
         public String offset;
         public int limit;
 
@@ -50534,7 +55809,7 @@ public class TLRPC {
             peer.serializeToStream(stream);
             stream.writeInt32(id);
             if ((flags & 1) != 0) {
-                stream.writeString(reaction);
+                reaction.serializeToStream(stream);
             }
             if ((flags & 2) != 0) {
                 stream.writeString(offset);
@@ -50544,10 +55819,10 @@ public class TLRPC {
     }
 
     public static class TL_messages_setChatAvailableReactions extends TLObject {
-        public static int constructor = 0x14050ea6;
+        public static int constructor = 0xfeb16771;
 
         public InputPeer peer;
-        public ArrayList<String> available_reactions = new ArrayList<>();
+        public ChatReactions available_reactions;
 
         public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
             return Updates.TLdeserialize(stream, constructor, exception);
@@ -50556,12 +55831,7 @@ public class TLRPC {
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
             peer.serializeToStream(stream);
-            stream.writeInt32(0x1cb5c415);
-            int count = available_reactions.size();
-            stream.writeInt32(count);
-            for (int a = 0; a < count; a++) {
-                stream.writeString(available_reactions.get(a));
-            }
+            available_reactions.serializeToStream(stream);
         }
     }
 
@@ -50753,7 +56023,7 @@ public class TLRPC {
             Vector vector = new Vector();
             int size = stream.readInt32(exception);
             for (int a = 0; a < size; a++) {
-                TL_dialogFilter object = TL_dialogFilter.TLdeserialize(stream, stream.readInt32(exception), exception);
+                DialogFilter object = DialogFilter.TLdeserialize(stream, stream.readInt32(exception), exception);
                 if (object == null) {
                     return vector;
                 }
@@ -51473,6 +56743,7 @@ public class TLRPC {
 
         public int flags;
         public boolean masks;
+        public boolean emojis;
         public ArrayList<Long> order = new ArrayList<>();
 
         public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
@@ -51482,6 +56753,7 @@ public class TLRPC {
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
             flags = masks ? (flags | 1) : (flags &~ 1);
+            flags = emojis ? (flags | 2) : (flags & ~2);
             stream.writeInt32(flags);
             stream.writeInt32(0x1cb5c415);
             int count = order.size();
@@ -51489,6 +56761,36 @@ public class TLRPC {
             for (int a = 0; a < count; a++) {
                 stream.writeInt64(order.get(a));
             }
+        }
+    }
+
+    public static class TL_messages_getEmojiStickers extends TLObject {
+        public static int constructor = 0xfbfca18f;
+
+        public long hash;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return messages_AllStickers.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt64(hash);
+        }
+    }
+
+    public static class TL_messages_getFeaturedEmojiStickers extends TLObject {
+        public static int constructor = 0xecf6736;
+
+        public long hash;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return messages_FeaturedStickers.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt64(hash);
         }
     }
 
@@ -51747,16 +57049,18 @@ public class TLRPC {
     }
 
     public static class TL_channels_createChannel extends TLObject {
-        public static int constructor = 0x3d5fb10f;
+        public static int constructor = 0x91006707;
 
         public int flags;
         public boolean broadcast;
         public boolean megagroup;
         public boolean for_import;
+        public boolean forum;
         public String title;
         public String about;
         public InputGeoPoint geo_point;
         public String address;
+        public int ttl_period;
 
         public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
             return Updates.TLdeserialize(stream, constructor, exception);
@@ -51767,6 +57071,7 @@ public class TLRPC {
             flags = broadcast ? (flags | 1) : (flags &~ 1);
             flags = megagroup ? (flags | 2) : (flags &~ 2);
             flags = for_import ? (flags | 8) : (flags &~ 8);
+            flags = forum ? (flags | 32) : (flags & ~32);
             stream.writeInt32(flags);
             stream.writeString(title);
             stream.writeString(about);
@@ -51775,6 +57080,9 @@ public class TLRPC {
             }
             if ((flags & 4) != 0) {
                 stream.writeString(address);
+            }
+            if ((flags & 16) != 0) {
+                stream.writeInt32(ttl_period);
             }
         }
     }
@@ -52202,7 +57510,7 @@ public class TLRPC {
         public InputChannel channel;
 
         public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
-            return TL_messages_sponsoredMessages.TLdeserialize(stream, constructor, exception);
+            return messages_SponsoredMessages.TLdeserialize(stream, constructor, exception);
         }
 
         public void serializeToStream(AbstractSerializedData stream) {
@@ -52232,6 +57540,8 @@ public class TLRPC {
         public int flags;
         public boolean masks;
         public boolean animated;
+        public boolean videos;
+        public boolean emojis;
         public InputUser user_id;
         public String title;
         public String short_name;
@@ -52240,13 +57550,15 @@ public class TLRPC {
         public String software;
 
         public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
-            return TL_messages_stickerSet.TLdeserialize(stream, constructor, exception);
+            return messages_StickerSet.TLdeserialize(stream, constructor, exception);
         }
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
             flags = masks ? (flags | 1) : (flags &~ 1);
             flags = animated ? (flags | 2) : (flags &~ 2);
+            flags = videos ? (flags | 16) : (flags & ~16);
+            flags = emojis ? (flags | 32) : (flags & ~32);
             stream.writeInt32(flags);
             user_id.serializeToStream(stream);
             stream.writeString(title);
@@ -52451,23 +57763,6 @@ public class TLRPC {
             stream.writeInt32(constructor);
             peer.serializeToStream(stream);
             debug.serializeToStream(stream);
-        }
-    }
-
-    public static class TL_phone_saveCallLog extends TLObject {
-        public static int constructor = 0x41248786;
-
-        public TL_inputPhoneCall peer;
-        public InputFile file;
-
-        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
-            return Bool.TLdeserialize(stream, constructor, exception);
-        }
-
-        public void serializeToStream(AbstractSerializedData stream) {
-            stream.writeInt32(constructor);
-            peer.serializeToStream(stream);
-            file.serializeToStream(stream);
         }
     }
 
@@ -53021,11 +58316,10 @@ public class TLRPC {
     }
 
     public static class TL_payments_getPaymentForm extends TLObject {
-        public static int constructor = 0x8a333c8d;
+        public static int constructor = 0x37148dbb;
 
         public int flags;
-        public InputPeer peer;
-        public int msg_id;
+        public InputInvoice invoice;
         public TL_dataJSON theme_params;
 
         public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
@@ -53035,8 +58329,7 @@ public class TLRPC {
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
             stream.writeInt32(flags);
-            peer.serializeToStream(stream);
-            stream.writeInt32(msg_id);
+            invoice.serializeToStream(stream);
             if ((flags & 1) != 0) {
                 theme_params.serializeToStream(stream);
             }
@@ -53061,12 +58354,11 @@ public class TLRPC {
     }
 
     public static class TL_payments_validateRequestedInfo extends TLObject {
-        public static int constructor = 0xdb103170;
+        public static int constructor = 0xb6c8f12b;
 
         public int flags;
         public boolean save;
-        public InputPeer peer;
-        public int msg_id;
+        public InputInvoice invoice;
         public TL_paymentRequestedInfo info;
 
         public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
@@ -53077,19 +58369,17 @@ public class TLRPC {
             stream.writeInt32(constructor);
             flags = save ? (flags | 1) : (flags &~ 1);
             stream.writeInt32(flags);
-            peer.serializeToStream(stream);
-            stream.writeInt32(msg_id);
+            invoice.serializeToStream(stream);
             info.serializeToStream(stream);
         }
     }
 
     public static class TL_payments_sendPaymentForm extends TLObject {
-        public static int constructor = 0x30c3bc9d;
+        public static int constructor = 0x2d03522f;
 
         public int flags;
         public long form_id;
-        public InputPeer peer;
-        public int msg_id;
+        public InputInvoice invoice;
         public String requested_info_id;
         public String shipping_option_id;
         public InputPaymentCredentials credentials;
@@ -53103,8 +58393,7 @@ public class TLRPC {
             stream.writeInt32(constructor);
             stream.writeInt32(flags);
             stream.writeInt64(form_id);
-            peer.serializeToStream(stream);
-            stream.writeInt32(msg_id);
+            invoice.serializeToStream(stream);
             if ((flags & 1) != 0) {
                 stream.writeString(requested_info_id);
             }
@@ -53223,6 +58512,89 @@ public class TLRPC {
             if ((flags & 2) != 0) {
                 wallpaper_settings.serializeToStream(stream);
             }
+        }
+    }
+
+    public static class TL_payments_assignPlayMarketTransaction extends TLObject {
+        public static int constructor = 0xdffd50d3;
+
+        public TL_dataJSON receipt;
+        public InputStorePaymentPurpose purpose;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Updates.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            receipt.serializeToStream(stream);
+            purpose.serializeToStream(stream);
+        }
+    }
+
+    public static abstract class InputStorePaymentPurpose extends TLObject {
+
+        public static InputStorePaymentPurpose TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
+            InputStorePaymentPurpose result = null;
+            switch (constructor) {
+                case 0xa6751e66:
+                    result = new TL_inputStorePaymentPremiumSubscription();
+                    break;
+                case 0x616f7fe8:
+                    result = new TL_inputStorePaymentGiftPremium();
+                    break;
+            }
+            if (result == null && exception) {
+                throw new RuntimeException(
+                        String.format("can't parse magic %x in InputStorePaymentPurpose", constructor));
+            }
+            if (result != null) {
+                result.readParams(stream, exception);
+            }
+            return result;
+        }
+    }
+
+    public static class TL_inputStorePaymentPremiumSubscription extends InputStorePaymentPurpose {
+        public static int constructor = 0xa6751e66;
+
+        public int flags;
+        public boolean restore;
+        public boolean upgrade;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            restore = (flags & 1) != 0;
+            upgrade = (flags & 2) != 0;
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = restore ? (flags | 1) : (flags & ~1);
+            flags = upgrade ? (flags | 2) : (flags & ~2);
+            stream.writeInt32(flags);
+        }
+    }
+
+    public static class TL_inputStorePaymentGiftPremium extends InputStorePaymentPurpose {
+        public static int constructor = 0x616f7fe8;
+
+        public InputUser user_id;
+        public String currency;
+        public long amount;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            user_id = InputUser.TLdeserialize(stream, stream.readInt32(exception), exception);
+            currency = stream.readString(exception);
+            amount = stream.readInt64(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            user_id.serializeToStream(stream);
+            stream.writeString(currency);
+            stream.writeInt64(amount);
         }
     }
 
@@ -53646,9 +59018,9 @@ public class TLRPC {
     //RichText end
 
     public static class TL_channels_sendAsPeers extends TLObject {
-        public static int constructor = 0x8356cda9;
+        public static int constructor = 0xf496b0c6;
 
-        public ArrayList<Peer> peers = new ArrayList<>();
+        public ArrayList<TL_sendAsPeer> peers = new ArrayList<>();
         public ArrayList<Chat> chats = new ArrayList<>();
         public ArrayList<User> users = new ArrayList<>();
 
@@ -53675,7 +59047,7 @@ public class TLRPC {
             }
             int count = stream.readInt32(exception);
             for (int a = 0; a < count; a++) {
-                Peer object = Peer.TLdeserialize(stream, stream.readInt32(exception), exception);
+                TL_sendAsPeer object = TL_sendAsPeer.TLdeserialize(stream, stream.readInt32(exception), exception);
                 if (object == null) {
                     return;
                 }
@@ -53736,6 +59108,40 @@ public class TLRPC {
         }
     }
 
+    public static class TL_sendAsPeer extends TLObject {
+        public static int constructor = 0xb81c7034;
+
+        public int flags;
+        public boolean premium_required;
+        public Peer peer;
+
+        public static TL_sendAsPeer TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+            if (TL_sendAsPeer.constructor != constructor) {
+                if (exception) {
+                    throw new RuntimeException(String.format("can't parse magic %x in TL_sendAsPeer", constructor));
+                } else {
+                    return null;
+                }
+            }
+            TL_sendAsPeer result = new TL_sendAsPeer();
+            result.readParams(stream, exception);
+            return result;
+        }
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            premium_required = (flags & 1) != 0;
+            peer = Peer.TLdeserialize(stream, stream.readInt32(exception), exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = premium_required ? (flags | 1) : (flags & ~1);
+            stream.writeInt32(flags);
+            peer.serializeToStream(stream);
+        }
+    }
+
     //MessageMedia start
     public static abstract class MessageMedia extends TLObject {
         public byte[] bytes;
@@ -53769,6 +59175,9 @@ public class TLRPC {
         public int period;
         public int ttl_seconds;
         public int proximity_notification_radius;
+        public boolean nopremium;
+        public MessageExtendedMedia extended_media;
+        public boolean spoiler;
 
         public static MessageMedia TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             MessageMedia result = null;
@@ -53783,6 +59192,9 @@ public class TLRPC {
                     result = new TL_messageMediaPhoto_old();
                     break;
                 case 0x84551347:
+                    result = new TL_messageMediaInvoice_layer145();
+                    break;
+                case 0xf6a548d3:
                     result = new TL_messageMediaInvoice();
                     break;
                 case 0x9f84f49e:
@@ -54263,7 +59675,7 @@ public class TLRPC {
     //EncryptedChat end
 
     //Message start
-    public static abstract class Message extends TLObject {
+    public static class Message extends TLObject {
         public int id;
         public Peer from_id;
         public Peer peer_id;
@@ -54299,6 +59711,7 @@ public class TLRPC {
         public ArrayList<TL_restrictionReason> restriction_reason = new ArrayList<>();
         public int ttl_period;
         public boolean noforwards;
+        public boolean topic_start;
         public int send_state = 0; //custom
         public int fwd_msg_id = 0; //custom
         public String attachPath = ""; //custom
@@ -54317,6 +59730,16 @@ public class TLRPC {
         public int realId; //custom
         public int stickerVerified = 1; //custom
         public boolean isThreadMessage; //custom
+        public String voiceTranscription; // custom
+        public boolean voiceTranscriptionOpen; // custom
+        public boolean voiceTranscriptionRated; // custom
+        public boolean voiceTranscriptionFinal; // custom
+        public boolean voiceTranscriptionForce; // custom
+        public long voiceTranscriptionId; // custom
+        public boolean premiumEffectWasPlayed; // custom
+        public String originalLanguage; // custom
+        public String translatedToLanguage; // custom
+        public TL_textWithEntities translatedText; // custom
 
         public static Message TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             Message result = null;
@@ -54419,12 +59842,16 @@ public class TLRPC {
                     break;
             }
             if (result == null && exception) {
-                 throw new RuntimeException(String.format("can't parse magic %x in Message", constructor));
+                throw new RuntimeException(String.format("can't parse magic %x in Message", constructor));
             }
             if (result != null) {
                 result.readParams(stream, exception);
                 if (result.from_id == null) {
-                    result.from_id = result.peer_id;
+                    if (result.id < 0 && result.random_id == 0) {
+                        result.from_id = new TL_peerUser();
+                    } else {
+                        result.from_id = result.peer_id;
+                    }
                 }
             }
             return result;
@@ -55111,6 +60538,7 @@ public class TLRPC {
             edit_hide = (flags & 2097152) != 0;
             pinned = (flags & 16777216) != 0;
             noforwards = (flags & 67108864) != 0;
+            topic_start = (flags & 134217728) != 0;
             id = stream.readInt32(exception);
             if ((flags & 256) != 0) {
                 from_id = Peer.TLdeserialize(stream, stream.readInt32(exception), exception);
@@ -55211,6 +60639,7 @@ public class TLRPC {
             flags = edit_hide ? (flags | 2097152) : (flags &~ 2097152);
             flags = pinned ? (flags | 16777216) : (flags &~ 16777216);
             flags = noforwards ? (flags | 67108864) : (flags &~ 67108864);
+            flags = topic_start ? (flags | 134217728) : (flags & ~134217728);
             stream.writeInt32(flags);
             stream.writeInt32(id);
             if ((flags & 256) != 0) {
@@ -56704,10 +62133,10 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = unread ? (flags | 1) : (flags &~ 1);
-            flags = out ? (flags | 2) : (flags &~ 2);
-            flags = mentioned ? (flags | 16) : (flags &~ 16);
-            flags = media_unread ? (flags | 32) : (flags &~ 32);
+            flags = unread ? (flags | 1) : (flags & ~1);
+            flags = out ? (flags | 2) : (flags & ~2);
+            flags = mentioned ? (flags | 16) : (flags & ~16);
+            flags = media_unread ? (flags | 32) : (flags & ~32);
             stream.writeInt32(flags);
             stream.writeInt32(id);
             stream.writeInt32((int) from_id.user_id);
@@ -56764,12 +62193,12 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = unread ? (flags | 1) : (flags &~ 1);
-            flags = out ? (flags | 2) : (flags &~ 2);
-            flags = mentioned ? (flags | 16) : (flags &~ 16);
-            flags = media_unread ? (flags | 32) : (flags &~ 32);
-            flags = silent ? (flags | 8192) : (flags &~ 8192);
-            flags = post ? (flags | 16384) : (flags &~ 16384);
+            flags = unread ? (flags | 1) : (flags & ~1);
+            flags = out ? (flags | 2) : (flags & ~2);
+            flags = mentioned ? (flags | 16) : (flags & ~16);
+            flags = media_unread ? (flags | 32) : (flags & ~32);
+            flags = silent ? (flags | 8192) : (flags & ~8192);
+            flags = post ? (flags | 16384) : (flags & ~16384);
             stream.writeInt32(flags);
             stream.writeInt32(id);
             if ((flags & 256) != 0) {
@@ -56819,10 +62248,10 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = unread ? (flags | 1) : (flags &~ 1);
-            flags = out ? (flags | 2) : (flags &~ 2);
-            flags = mentioned ? (flags | 16) : (flags &~ 16);
-            flags = media_unread ? (flags | 32) : (flags &~ 32);
+            flags = unread ? (flags | 1) : (flags & ~1);
+            flags = out ? (flags | 2) : (flags & ~2);
+            flags = mentioned ? (flags | 16) : (flags & ~16);
+            flags = media_unread ? (flags | 32) : (flags & ~32);
             stream.writeInt32(flags);
             stream.writeInt32(id);
             stream.writeInt32((int) from_id.user_id);
@@ -56878,10 +62307,10 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = unread ? (flags | 1) : (flags &~ 1);
-            flags = out ? (flags | 2) : (flags &~ 2);
-            flags = mentioned ? (flags | 16) : (flags &~ 16);
-            flags = media_unread ? (flags | 32) : (flags &~ 32);
+            flags = unread ? (flags | 1) : (flags & ~1);
+            flags = out ? (flags | 2) : (flags & ~2);
+            flags = mentioned ? (flags | 16) : (flags & ~16);
+            flags = media_unread ? (flags | 32) : (flags & ~32);
             stream.writeInt32(flags);
             stream.writeInt32(id);
             stream.writeInt32((int) from_id.user_id);
@@ -56924,10 +62353,10 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = unread ? (flags | 1) : (flags &~ 1);
-            flags = out ? (flags | 2) : (flags &~ 2);
-            flags = mentioned ? (flags | 16) : (flags &~ 16);
-            flags = media_unread ? (flags | 32) : (flags &~ 32);
+            flags = unread ? (flags | 1) : (flags & ~1);
+            flags = out ? (flags | 2) : (flags & ~2);
+            flags = mentioned ? (flags | 16) : (flags & ~16);
+            flags = media_unread ? (flags | 32) : (flags & ~32);
             stream.writeInt32(flags);
             stream.writeInt32(id);
             stream.writeInt32((int) from_id.user_id);
@@ -57090,10 +62519,10 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = unread ? (flags | 1) : (flags &~ 1);
-            flags = out ? (flags | 2) : (flags &~ 2);
-            flags = mentioned ? (flags | 16) : (flags &~ 16);
-            flags = media_unread ? (flags | 32) : (flags &~ 32);
+            flags = unread ? (flags | 1) : (flags & ~1);
+            flags = out ? (flags | 2) : (flags & ~2);
+            flags = mentioned ? (flags | 16) : (flags & ~16);
+            flags = media_unread ? (flags | 32) : (flags & ~32);
             stream.writeInt32(flags);
             stream.writeInt32(id);
             stream.writeInt32(ttl);
@@ -57167,10 +62596,10 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = unread ? (flags | 1) : (flags &~ 1);
-            flags = out ? (flags | 2) : (flags &~ 2);
-            flags = mentioned ? (flags | 16) : (flags &~ 16);
-            flags = media_unread ? (flags | 32) : (flags &~ 32);
+            flags = unread ? (flags | 1) : (flags & ~1);
+            flags = out ? (flags | 2) : (flags & ~2);
+            flags = mentioned ? (flags | 16) : (flags & ~16);
+            flags = media_unread ? (flags | 32) : (flags & ~32);
             stream.writeInt32(flags);
             stream.writeInt32(id);
             stream.writeInt32(ttl);
@@ -57219,10 +62648,10 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = unread ? (flags | 1) : (flags &~ 1);
-            flags = out ? (flags | 2) : (flags &~ 2);
-            flags = mentioned ? (flags | 16) : (flags &~ 16);
-            flags = media_unread ? (flags | 32) : (flags &~ 32);
+            flags = unread ? (flags | 1) : (flags & ~1);
+            flags = out ? (flags | 2) : (flags & ~2);
+            flags = mentioned ? (flags | 16) : (flags & ~16);
+            flags = media_unread ? (flags | 32) : (flags & ~32);
             stream.writeInt32(flags);
             stream.writeInt32(id);
             stream.writeInt32(ttl);
@@ -57261,12 +62690,12 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = out ? (flags | 2) : (flags &~ 2);
-            flags = mentioned ? (flags | 16) : (flags &~ 16);
-            flags = media_unread ? (flags | 32) : (flags &~ 32);
-            flags = silent ? (flags | 8192) : (flags &~ 8192);
-            flags = post ? (flags | 16384) : (flags &~ 16384);
-            flags = legacy ? (flags | 524288) : (flags &~ 524288);
+            flags = out ? (flags | 2) : (flags & ~2);
+            flags = mentioned ? (flags | 16) : (flags & ~16);
+            flags = media_unread ? (flags | 32) : (flags & ~32);
+            flags = silent ? (flags | 8192) : (flags & ~8192);
+            flags = post ? (flags | 16384) : (flags & ~16384);
+            flags = legacy ? (flags | 524288) : (flags & ~524288);
             stream.writeInt32(flags);
             stream.writeInt32(id);
             if ((flags & 256) != 0) {
@@ -57311,12 +62740,12 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = out ? (flags | 2) : (flags &~ 2);
-            flags = mentioned ? (flags | 16) : (flags &~ 16);
-            flags = media_unread ? (flags | 32) : (flags &~ 32);
-            flags = silent ? (flags | 8192) : (flags &~ 8192);
-            flags = post ? (flags | 16384) : (flags &~ 16384);
-            flags = legacy ? (flags | 524288) : (flags &~ 524288);
+            flags = out ? (flags | 2) : (flags & ~2);
+            flags = mentioned ? (flags | 16) : (flags & ~16);
+            flags = media_unread ? (flags | 32) : (flags & ~32);
+            flags = silent ? (flags | 8192) : (flags & ~8192);
+            flags = post ? (flags | 16384) : (flags & ~16384);
+            flags = legacy ? (flags | 524288) : (flags & ~524288);
             stream.writeInt32(flags);
             stream.writeInt32(id);
             if ((flags & 256) != 0) {
@@ -57362,13 +62791,13 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = unread ? (flags | 1) : (flags &~ 1);
-            flags = out ? (flags | 2) : (flags &~ 2);
-            flags = mentioned ? (flags | 16) : (flags &~ 16);
-            flags = media_unread ? (flags | 32) : (flags &~ 32);
-            flags = silent ? (flags | 8192) : (flags &~ 8192);
-            flags = post ? (flags | 16384) : (flags &~ 16384);
-            flags = legacy ? (flags | 524288) : (flags &~ 524288);
+            flags = unread ? (flags | 1) : (flags & ~1);
+            flags = out ? (flags | 2) : (flags & ~2);
+            flags = mentioned ? (flags | 16) : (flags & ~16);
+            flags = media_unread ? (flags | 32) : (flags & ~32);
+            flags = silent ? (flags | 8192) : (flags & ~8192);
+            flags = post ? (flags | 16384) : (flags & ~16384);
+            flags = legacy ? (flags | 524288) : (flags & ~524288);
             stream.writeInt32(flags);
             stream.writeInt32(id);
             if ((flags & 256) != 0) {
@@ -57383,9 +62812,9 @@ public class TLRPC {
             writeAttachPath(stream);
         }
     }
-    //Message end
+    // Message end
 
-    //TL_dialog start
+    // TL_dialog start
     public static abstract class Dialog extends TLObject {
 
         public int flags;
@@ -57402,18 +62831,24 @@ public class TLRPC {
         public int pts;
         public DraftMessage draft;
         public int folder_id;
-        public int last_message_date; //custom
-        public long id; //custom
-        public int pinnedNum; //custom
+        public int ttl_period;
+        public int last_message_date; // custom
+        public long id; // custom
+        public int pinnedNum; // custom
+        public boolean isFolder; // custom
 
         public static Dialog TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
             Dialog result = null;
             switch (constructor) {
-                case 0xa8edd0f5:
+                case 0xd58a08c6:
                     result = new TL_dialog();
+                    break;
+                case 0xa8edd0f5:
+                    result = new TL_dialog_layer149();
                     break;
                 case 0x71bd134c:
                     result = new TL_dialogFolder();
+                    result.isFolder = true;
                     break;
             }
             if (result == null && exception) {
@@ -57427,6 +62862,63 @@ public class TLRPC {
     }
 
     public static class TL_dialog extends Dialog {
+        public static int constructor = 0xd58a08c6;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            pinned = (flags & 4) != 0;
+            unread_mark = (flags & 8) != 0;
+            peer = Peer.TLdeserialize(stream, stream.readInt32(exception), exception);
+            top_message = stream.readInt32(exception);
+            read_inbox_max_id = stream.readInt32(exception);
+            read_outbox_max_id = stream.readInt32(exception);
+            unread_count = stream.readInt32(exception);
+            unread_mentions_count = stream.readInt32(exception);
+            unread_reactions_count = stream.readInt32(exception);
+            notify_settings = TL_peerNotifySettings.TLdeserialize(stream, stream.readInt32(exception), exception);
+            if ((flags & 1) != 0) {
+                pts = stream.readInt32(exception);
+            }
+            if ((flags & 2) != 0) {
+                draft = DraftMessage.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 16) != 0) {
+                folder_id = stream.readInt32(exception);
+            }
+            if ((flags & 32) != 0) {
+                ttl_period = stream.readInt32(exception);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = pinned ? (flags | 4) : (flags & ~4);
+            flags = unread_mark ? (flags | 8) : (flags & ~8);
+            stream.writeInt32(flags);
+            peer.serializeToStream(stream);
+            stream.writeInt32(top_message);
+            stream.writeInt32(read_inbox_max_id);
+            stream.writeInt32(read_outbox_max_id);
+            stream.writeInt32(unread_count);
+            stream.writeInt32(unread_mentions_count);
+            stream.writeInt32(unread_reactions_count);
+            notify_settings.serializeToStream(stream);
+            if ((flags & 1) != 0) {
+                stream.writeInt32(pts);
+            }
+            if ((flags & 2) != 0) {
+                draft.serializeToStream(stream);
+            }
+            if ((flags & 16) != 0) {
+                stream.writeInt32(folder_id);
+            }
+            if ((flags & 32) != 0) {
+                stream.writeInt32(ttl_period);
+            }
+        }
+    }
+
+    public static class TL_dialog_layer149 extends TL_dialog {
         public static int constructor = 0xa8edd0f5;
 
         public void readParams(AbstractSerializedData stream, boolean exception) {
@@ -57450,12 +62942,15 @@ public class TLRPC {
             if ((flags & 16) != 0) {
                 folder_id = stream.readInt32(exception);
             }
+            if ((flags & 32) != 0) {
+                ttl_period = stream.readInt32(exception);
+            }
         }
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = pinned ? (flags | 4) : (flags &~ 4);
-            flags = unread_mark ? (flags | 8) : (flags &~ 8);
+            flags = pinned ? (flags | 4) : (flags & ~4);
+            flags = unread_mark ? (flags | 8) : (flags & ~8);
             stream.writeInt32(flags);
             peer.serializeToStream(stream);
             stream.writeInt32(top_message);
@@ -57473,6 +62968,9 @@ public class TLRPC {
             }
             if ((flags & 16) != 0) {
                 stream.writeInt32(folder_id);
+            }
+            if ((flags & 32) != 0) {
+                stream.writeInt32(ttl_period);
             }
         }
     }
@@ -57500,7 +62998,7 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = pinned ? (flags | 4) : (flags &~ 4);
+            flags = pinned ? (flags | 4) : (flags & ~4);
             stream.writeInt32(flags);
             folder.serializeToStream(stream);
             peer.serializeToStream(stream);
@@ -57511,17 +63009,17 @@ public class TLRPC {
             stream.writeInt32(unread_unmuted_messages_count);
         }
     }
-    //TL_dialog end
+    // TL_dialog end
 
-    //ChatParticipant start
+    // ChatParticipant start
     public static class TL_chatChannelParticipant extends ChatParticipant {
         public static int constructor = 0xc8d7493e;
 
         public ChannelParticipant channelParticipant;
     }
-    //ChatParticipant end
+    // ChatParticipant end
 
-    //Chat start
+    // Chat start
     public static class TL_chatEmpty extends Chat {
         public static int constructor = 0x29562865;
 
@@ -57553,9 +63051,9 @@ public class TLRPC {
             stream.writeInt32((int) id);
         }
     }
-    //Chat end
+    // Chat end
 
-    //functions memory optimize
+    // functions memory optimize
     public static class TL_upload_saveFilePart extends TLObject {
         public static int constructor = 0xb304a621;
 
@@ -57670,10 +63168,10 @@ public class TLRPC {
     }
 
     public static class TL_upload_getCdnFile extends TLObject {
-        public static int constructor = 0x2000bcc3;
+        public static int constructor = 0x395f69da;
 
         public byte[] file_token;
-        public int offset;
+        public long offset;
         public int limit;
 
         public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
@@ -57683,7 +63181,7 @@ public class TLRPC {
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
             stream.writeByteArray(file_token);
-            stream.writeInt32(offset);
+            stream.writeInt64(offset);
             stream.writeInt32(limit);
         }
     }
@@ -57715,10 +63213,10 @@ public class TLRPC {
     }
 
     public static class TL_upload_getCdnFileHashes extends TLObject {
-        public static int constructor = 0x4da54231;
+        public static int constructor = 0x91dc3f31;
 
         public byte[] file_token;
-        public int offset;
+        public long offset;
 
         public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
             Vector vector = new Vector();
@@ -57736,7 +63234,7 @@ public class TLRPC {
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
             stream.writeByteArray(file_token);
-            stream.writeInt32(offset);
+            stream.writeInt64(offset);
         }
     }
 
@@ -57775,7 +63273,8 @@ public class TLRPC {
         public int mtime;
         public NativeByteBuffer bytes;
 
-        public static TL_upload_webFile TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+        public static TL_upload_webFile TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
             if (TL_upload_webFile.constructor != constructor) {
                 if (exception) {
                     throw new RuntimeException(String.format("can't parse magic %x in TL_upload_webFile", constructor));
@@ -57988,7 +63487,8 @@ public class TLRPC {
         public int max_layer;
         public ArrayList<String> library_versions = new ArrayList<>();
 
-        public static PhoneCallProtocol TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+        public static PhoneCallProtocol TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
             PhoneCallProtocol result = null;
             switch (constructor) {
                 case 0xfc878fc8:
@@ -58033,8 +63533,8 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = udp_p2p ? (flags | 1) : (flags &~ 1);
-            flags = udp_reflector ? (flags | 2) : (flags &~ 2);
+            flags = udp_p2p ? (flags | 1) : (flags & ~1);
+            flags = udp_reflector ? (flags | 2) : (flags & ~2);
             stream.writeInt32(flags);
             stream.writeInt32(min_layer);
             stream.writeInt32(max_layer);
@@ -58061,8 +63561,8 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = udp_p2p ? (flags | 1) : (flags &~ 1);
-            flags = udp_reflector ? (flags | 2) : (flags &~ 2);
+            flags = udp_p2p ? (flags | 1) : (flags & ~1);
+            flags = udp_reflector ? (flags | 2) : (flags & ~2);
             stream.writeInt32(flags);
             stream.writeInt32(min_layer);
             stream.writeInt32(max_layer);
@@ -58085,7 +63585,7 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = silent ? (flags | 1) : (flags &~ 1);
+            flags = silent ? (flags | 1) : (flags & ~1);
             stream.writeInt32(flags);
             peer.serializeToStream(stream);
             stream.writeInt64(random_id);
@@ -58137,7 +63637,7 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = silent ? (flags | 1) : (flags &~ 1);
+            flags = silent ? (flags | 1) : (flags & ~1);
             stream.writeInt32(flags);
             peer.serializeToStream(stream);
             stream.writeInt64(random_id);
@@ -58201,14 +63701,8 @@ public class TLRPC {
         }
     }
 
-    public static class TL_attachMenuBot extends TLObject {
+    public static class TL_attachMenuBot_layer140 extends TL_attachMenuBot {
         public static int constructor = 0xe93cb772;
-
-        public int flags;
-        public boolean inactive;
-        public long bot_id;
-        public String short_name;
-        public ArrayList<TL_attachMenuBotIcon> icons = new ArrayList<>();
 
         public static TL_attachMenuBot TLdeserialize(AbstractSerializedData stream, int constructor,
                 boolean exception) {
@@ -58262,6 +63756,105 @@ public class TLRPC {
         }
     }
 
+    public static class TL_attachMenuBot extends AttachMenuBot {
+        public static int constructor = 0xc8aa2cd2;
+
+        public int flags;
+        public boolean inactive;
+        public boolean has_settings;
+        public boolean request_write_access;
+        public long bot_id;
+        public String short_name;
+        public ArrayList<AttachMenuPeerType> peer_types = new ArrayList<>();
+        public ArrayList<TL_attachMenuBotIcon> icons = new ArrayList<>();
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            inactive = (flags & 1) != 0;
+            has_settings = (flags & 2) != 0;
+            request_write_access = (flags & 4) != 0;
+            bot_id = stream.readInt64(exception);
+            short_name = stream.readString(exception);
+            int magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            int count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                AttachMenuPeerType object = AttachMenuPeerType.TLdeserialize(stream, stream.readInt32(exception),
+                        exception);
+                if (object == null) {
+                    return;
+                }
+                peer_types.add(object);
+            }
+            magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                TL_attachMenuBotIcon object = TL_attachMenuBotIcon.TLdeserialize(stream, stream.readInt32(exception),
+                        exception);
+                if (object == null) {
+                    return;
+                }
+                icons.add(object);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = inactive ? (flags | 1) : (flags & ~1);
+            flags = has_settings ? (flags | 2) : (flags & ~2);
+            flags = request_write_access ? (flags | 4) : (flags & ~4);
+            stream.writeInt32(flags);
+            stream.writeInt64(bot_id);
+            stream.writeString(short_name);
+            stream.writeInt32(0x1cb5c415);
+            int count = peer_types.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                peer_types.get(a).serializeToStream(stream);
+            }
+            stream.writeInt32(0x1cb5c415);
+            count = icons.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                icons.get(a).serializeToStream(stream);
+            }
+        }
+    }
+
+    public static abstract class AttachMenuBot extends TLObject {
+
+        public static TL_attachMenuBot TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
+            TL_attachMenuBot result = null;
+            switch (constructor) {
+                case 0xe93cb772:
+                    result = new TL_attachMenuBot_layer140();
+                    break;
+                case 0xc8aa2cd2:
+                    result = new TL_attachMenuBot();
+                    break;
+            }
+            if (result == null && exception) {
+                throw new RuntimeException(String.format("can't parse magic %x in AttachMenuBot", constructor));
+            }
+            if (result != null) {
+                result.readParams(stream, exception);
+            }
+            return result;
+        }
+    }
+
     public static abstract class AttachMenuBots extends TLObject {
 
         public static AttachMenuBots TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
@@ -58286,6 +63879,7 @@ public class TLRPC {
 
     public static class TL_attachMenuBotsNotModified extends AttachMenuBots {
         public static int constructor = 0xf1d88a5c;
+
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
@@ -58354,6 +63948,7 @@ public class TLRPC {
 
     public static class TL_updateAttachMenuBots extends Update {
         public static int constructor = 0x17b7a20b;
+
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
@@ -58427,6 +64022,170 @@ public class TLRPC {
         }
     }
 
+    public static class RequestPeerType extends TLObject {
+
+        public int flags;
+
+        public Boolean creator;
+        public TL_chatAdminRights user_admin_rights;
+        public TL_chatAdminRights bot_admin_rights;
+        public Boolean has_username;
+        public Boolean forum;
+        public Boolean bot_participant;
+
+        public static RequestPeerType TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+            RequestPeerType result = null;
+            switch (constructor) {
+                case TL_requestPeerTypeUser.constructor:
+                    result = new TL_requestPeerTypeUser();
+                    break;
+                case TL_requestPeerTypeChat.constructor:
+                    result = new TL_requestPeerTypeChat();
+                    break;
+                case TL_requestPeerTypeBroadcast.constructor:
+                    result = new TL_requestPeerTypeBroadcast();
+                    break;
+            }
+            if (result == null && exception) {
+                throw new RuntimeException(String.format("can't parse magic %x in RequestPeerType", constructor));
+            }
+            if (result != null) {
+                result.readParams(stream, exception);
+            }
+            return result;
+        }
+    }
+
+    public static class TL_requestPeerTypeUser extends RequestPeerType {
+        public static final int constructor = 0x5f3b8a00;
+
+        public Boolean bot;
+        public Boolean premium;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            if ((flags & 1) != 0) {
+                bot = stream.readBool(exception);
+            }
+            if ((flags & 2) != 0) {
+                premium = stream.readBool(exception);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = bot != null ? (flags | 1) : (flags & ~1);
+            flags = premium != null ? (flags | 2) : (flags & ~2);
+            stream.writeInt32(flags);
+            if (bot != null) {
+                stream.writeBool(bot);
+            }
+            if (premium != null) {
+                stream.writeBool(premium);
+            }
+        }
+    }
+
+    public static class TL_requestPeerTypeChat extends RequestPeerType {
+        public static final int constructor = 0xc9f06e1b;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            bot_participant = (flags & 32) != 0;
+            creator = (flags & 1) != 0;
+            if ((flags & 8) != 0) {
+                has_username = stream.readBool(exception);
+            }
+            if ((flags & 16) != 0) {
+                forum = stream.readBool(exception);
+            }
+            if ((flags & 2) != 0) {
+                user_admin_rights = TL_chatAdminRights.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 4) != 0) {
+                bot_admin_rights = TL_chatAdminRights.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = creator != null && creator ? (flags | 1) : (flags & ~1);
+            flags = user_admin_rights != null ? (flags | 2) : (flags & ~2);
+            flags = bot_admin_rights != null ? (flags | 4) : (flags & ~4);
+            flags = has_username != null ? (flags | 8) : (flags & ~8);
+            flags = forum != null ? (flags | 16) : (flags & ~16);
+            flags = bot_participant != null && bot_participant ? (flags | 32) : (flags & ~32);
+            stream.writeInt32(flags);
+            if (has_username != null) {
+                stream.writeBool(has_username);
+            }
+            if (forum != null) {
+                stream.writeBool(forum);
+            }
+            if (user_admin_rights != null) {
+                user_admin_rights.serializeToStream(stream);
+            }
+            if (bot_admin_rights != null) {
+                bot_admin_rights.serializeToStream(stream);
+            }
+        }
+    }
+
+    public static class TL_requestPeerTypeBroadcast extends RequestPeerType {
+        public static final int constructor = 0x339bef6c;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            creator = (flags & 1) != 0;
+            if ((flags & 8) != 0) {
+                has_username = stream.readBool(exception);
+            }
+            if ((flags & 2) != 0) {
+                user_admin_rights = TL_chatAdminRights.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+            if ((flags & 4) != 0) {
+                bot_admin_rights = TL_chatAdminRights.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = creator != null && creator ? (flags | 1) : (flags & ~1);
+            flags = user_admin_rights != null ? (flags | 2) : (flags & ~2);
+            flags = bot_admin_rights != null ? (flags | 4) : (flags & ~4);
+            flags = has_username != null ? (flags | 8) : (flags & ~8);
+            stream.writeInt32(flags);
+            if (has_username != null) {
+                stream.writeBool(has_username);
+            }
+            if (user_admin_rights != null) {
+                user_admin_rights.serializeToStream(stream);
+            }
+            if (bot_admin_rights != null) {
+                bot_admin_rights.serializeToStream(stream);
+            }
+        }
+    }
+
+    public static class TL_keyboardButtonRequestPeer extends KeyboardButton {
+        public static int constructor = 0xd0b468c;
+
+        public RequestPeerType peer_type;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            text = stream.readString(exception);
+            button_id = stream.readInt32(exception);
+            peer_type = RequestPeerType.TLdeserialize(stream, stream.readInt32(exception), exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeString(text);
+            stream.writeInt32(button_id);
+            peer_type.serializeToStream(stream);
+        }
+    }
+
     public static class TL_messages_getAttachMenuBots extends TLObject {
         public static int constructor = 0x16fcc2cb;
 
@@ -58443,8 +64202,10 @@ public class TLRPC {
     }
 
     public static class TL_messages_toggleBotInAttachMenu extends TLObject {
-        public static int constructor = 0x1aee33af;
+        public static int constructor = 0x69f59d69;
 
+        public int flags;
+        public boolean write_allowed;
         public InputUser bot;
         public boolean enabled;
 
@@ -58454,6 +64215,8 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
+            flags = write_allowed ? (flags | 1) : (flags & ~1);
+            stream.writeInt32(flags);
             bot.serializeToStream(stream);
             stream.writeBool(enabled);
         }
@@ -58493,18 +64256,19 @@ public class TLRPC {
     }
 
     public static class TL_messages_requestWebView extends TLObject {
-        public static int constructor = 0xfa04dff;
+        public static int constructor = 0xfc87a53c;
 
         public int flags;
+        public boolean from_bot_menu;
         public boolean silent;
-        public boolean background;
         public InputPeer peer;
         public InputUser bot;
         public String url;
         public String start_param;
         public TL_dataJSON theme_params;
+        public String platform;
         public int reply_to_msg_id;
-        public boolean from_bot_menu;
+        public InputPeer send_as;
 
         public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
             return TL_webViewResultUrl.TLdeserialize(stream, constructor, exception);
@@ -58512,9 +64276,8 @@ public class TLRPC {
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
-            flags = silent ? (flags | 32) : (flags & ~32);
-            flags = background ? (flags | 64) : (flags & ~64);
             flags = from_bot_menu ? (flags | 16) : (flags & ~16);
+            flags = silent ? (flags | 32) : (flags & ~32);
             stream.writeInt32(flags);
             peer.serializeToStream(stream);
             bot.serializeToStream(stream);
@@ -58527,14 +64290,18 @@ public class TLRPC {
             if ((flags & 4) != 0) {
                 theme_params.serializeToStream(stream);
             }
+            stream.writeString(platform);
             if ((flags & 1) != 0) {
                 stream.writeInt32(reply_to_msg_id);
+            }
+            if ((flags & 8192) != 0) {
+                send_as.serializeToStream(stream);
             }
         }
     }
 
     public static class TL_messages_prolongWebView extends TLObject {
-        public static int constructor = 0xd22ad148;
+        public static int constructor = 0xea5fbcce;
 
         public int flags;
         public boolean silent;
@@ -58542,6 +64309,7 @@ public class TLRPC {
         public InputUser bot;
         public long query_id;
         public int reply_to_msg_id;
+        public InputPeer send_as;
 
         public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
             return Bool.TLdeserialize(stream, constructor, exception);
@@ -58557,16 +64325,20 @@ public class TLRPC {
             if ((flags & 1) != 0) {
                 stream.writeInt32(reply_to_msg_id);
             }
+            if ((flags & 8192) != 0) {
+                send_as.serializeToStream(stream);
+            }
         }
     }
 
     public static class TL_messages_requestSimpleWebView extends TLObject {
-        public static int constructor = 0x6abb2f73;
+        public static int constructor = 0x299bec8e;
 
         public int flags;
         public InputUser bot;
         public String url;
         public TL_dataJSON theme_params;
+        public String platform;
 
         public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
             return TL_simpleWebViewResultUrl.TLdeserialize(stream, constructor, exception);
@@ -58580,6 +64352,7 @@ public class TLRPC {
             if ((flags & 1) != 0) {
                 theme_params.serializeToStream(stream);
             }
+            stream.writeString(platform);
         }
     }
 
@@ -58823,6 +64596,7 @@ public class TLRPC {
     public static class TL_account_savedRingtonesNotModified extends account_SavedRingtones {
         public static int constructor = 0xfbf6e8b1;
 
+
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
         }
@@ -59058,6 +64832,7 @@ public class TLRPC {
     public static class TL_botMenuButtonDefault extends BotMenuButton {
         public static int constructor = 0x7533a588;
 
+
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
         }
@@ -59065,6 +64840,7 @@ public class TLRPC {
 
     public static class TL_botMenuButtonCommands extends BotMenuButton {
         public static int constructor = 0x4258c205;
+
 
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
@@ -59162,14 +64938,1620 @@ public class TLRPC {
     public static class TL_account_savedRingtone extends account_SavedRingtone {
         public static int constructor = 0xb7263f6d;
 
+
         public void serializeToStream(AbstractSerializedData stream) {
             stream.writeInt32(constructor);
         }
     }
+
+    public static class TL_channels_toggleJoinToSend extends TLObject {
+        public static int constructor = 0xe4cb9580;
+
+        public InputChannel channel;
+        public boolean enabled;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Updates.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            channel.serializeToStream(stream);
+            stream.writeBool(enabled);
+        }
+    }
+
+    public static class TL_channels_toggleJoinRequest extends TLObject {
+        public static int constructor = 0x4c2985b6;
+
+        public InputChannel channel;
+        public boolean enabled;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Updates.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            channel.serializeToStream(stream);
+            stream.writeBool(enabled);
+        }
+    }
+
+    public static class TL_chatInvitePublicJoinRequests extends TL_chatInviteExported {
+        public static int constructor = 0xed107ab7;
+
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+
+        }
+    }
+
+    public static class TL_phone_saveCallLog extends TLObject {
+        public static int constructor = 0x41248786;
+
+        public TL_inputPhoneCall peer;
+        public InputFile file;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Bool.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            peer.serializeToStream(stream);
+            file.serializeToStream(stream);
+        }
+    }
+
+    public static abstract class AttachMenuPeerType extends TLObject {
+
+        public static AttachMenuPeerType TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
+            AttachMenuPeerType result = null;
+            switch (constructor) {
+                case 0xc32bfa1a:
+                    result = new TL_attachMenuPeerTypeBotPM();
+                    break;
+                case 0xf146d31f:
+                    result = new TL_attachMenuPeerTypePM();
+                    break;
+                case 0x7bfbdefc:
+                    result = new TL_attachMenuPeerTypeBroadcast();
+                    break;
+                case 0x509113f:
+                    result = new TL_attachMenuPeerTypeChat();
+                    break;
+                case 0x7d6be90e:
+                    result = new TL_attachMenuPeerTypeSameBotPM();
+                    break;
+            }
+            if (result == null && exception) {
+                throw new RuntimeException(String.format("can't parse magic %x in AttachMenuPeerType", constructor));
+            }
+            if (result != null) {
+                result.readParams(stream, exception);
+            }
+            return result;
+        }
+    }
+
+    public static class TL_attachMenuPeerTypeBotPM extends AttachMenuPeerType {
+        public static int constructor = 0xc32bfa1a;
+
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
+    public static class TL_attachMenuPeerTypePM extends AttachMenuPeerType {
+        public static int constructor = 0xf146d31f;
+
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
+    public static class TL_attachMenuPeerTypeBroadcast extends AttachMenuPeerType {
+        public static int constructor = 0x7bfbdefc;
+
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
+    public static class TL_attachMenuPeerTypeChat extends AttachMenuPeerType {
+        public static int constructor = 0x509113f;
+
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
+    public static class TL_attachMenuPeerTypeSameBotPM extends AttachMenuPeerType {
+        public static int constructor = 0x7d6be90e;
+
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
+    public static abstract class InputInvoice extends TLObject {
+
+        public static InputInvoice TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+            InputInvoice result = null;
+            switch (constructor) {
+                case 0xc5b56859:
+                    result = new TL_inputInvoiceMessage();
+                    break;
+                case 0xc326caef:
+                    result = new TL_inputInvoiceSlug();
+                    break;
+            }
+            if (result == null && exception) {
+                throw new RuntimeException(String.format("can't parse magic %x in InputInvoice", constructor));
+            }
+            if (result != null) {
+                result.readParams(stream, exception);
+            }
+            return result;
+        }
+    }
+
+    public static class TL_inputInvoiceMessage extends InputInvoice {
+        public static int constructor = 0xc5b56859;
+
+        public InputPeer peer;
+        public int msg_id;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            peer = InputPeer.TLdeserialize(stream, stream.readInt32(exception), exception);
+            msg_id = stream.readInt32(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            peer.serializeToStream(stream);
+            stream.writeInt32(msg_id);
+        }
+    }
+
+    public static class TL_inputInvoiceSlug extends InputInvoice {
+        public static int constructor = 0xc326caef;
+
+        public String slug;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            slug = stream.readString(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeString(slug);
+        }
+    }
+
+    public static class TL_payments_exportedInvoice extends TLObject {
+        public static int constructor = 0xaed0cbd9;
+
+        public String url;
+
+        public static TL_payments_exportedInvoice TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
+            if (TL_payments_exportedInvoice.constructor != constructor) {
+                if (exception) {
+                    throw new RuntimeException(
+                            String.format("can't parse magic %x in TL_payments_exportedInvoice", constructor));
+                } else {
+                    return null;
+                }
+            }
+            TL_payments_exportedInvoice result = new TL_payments_exportedInvoice();
+            result.readParams(stream, exception);
+            return result;
+        }
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            url = stream.readString(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeString(url);
+        }
+    }
+
+    public static class TL_payments_exportInvoice extends TLObject {
+        public static int constructor = 0xf91b065;
+
+        public InputMedia invoice_media;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return TL_payments_exportedInvoice.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            invoice_media.serializeToStream(stream);
+        }
+    }
+
+    public static class TL_messages_transcribeAudio extends TLObject {
+        public static int constructor = 0x269e9a49;
+
+        public InputPeer peer;
+        public int msg_id;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return TL_messages_transcribedAudio.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            peer.serializeToStream(stream);
+            stream.writeInt32(msg_id);
+        }
+    }
+
+    public static class TL_messages_rateTranscribedAudio extends TLObject {
+        public static int constructor = 0x7f1d072f;
+
+        public InputPeer peer;
+        public int msg_id;
+        public long transcription_id;
+        public boolean good;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Bool.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            peer.serializeToStream(stream);
+            stream.writeInt32(msg_id);
+            stream.writeInt64(transcription_id);
+            stream.writeBool(good);
+        }
+    }
+
+    public static class TL_messages_transcribedAudio extends TLObject {
+        public static int constructor = 0x93752c52;
+
+        public int flags;
+        public boolean pending;
+        public long transcription_id;
+        public String text;
+
+        public static TL_messages_transcribedAudio TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
+            if (TL_messages_transcribedAudio.constructor != constructor) {
+                if (exception) {
+                    throw new RuntimeException(
+                            String.format("can't parse magic %x in TL_messages_transcribedAudio", constructor));
+                } else {
+                    return null;
+                }
+            }
+            TL_messages_transcribedAudio result = new TL_messages_transcribedAudio();
+            result.readParams(stream, exception);
+            return result;
+        }
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            pending = (flags & 1) != 0;
+            transcription_id = stream.readInt64(exception);
+            text = stream.readString(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = pending ? (flags | 1) : (flags & ~1);
+            stream.writeInt32(flags);
+            stream.writeInt64(transcription_id);
+            stream.writeString(text);
+        }
+    }
+
+    public static class TL_payments_canPurchasePremium extends TLObject {
+        public static int constructor = 0x9fc19eb6;
+
+        public InputStorePaymentPurpose purpose;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Bool.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            purpose.serializeToStream(stream);
+        }
+    }
+
+    public static class TL_payments_requestRecurringPayment extends TLObject {
+        public static int constructor = 0x146e958d;
+
+        public InputUser user_id;
+        public String recurring_init_charge;
+        public InputMedia invoice_media;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Updates.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            user_id.serializeToStream(stream);
+            stream.writeString(recurring_init_charge);
+            invoice_media.serializeToStream(stream);
+        }
+    }
+
+    public static class TL_messageEntityCustomEmoji extends MessageEntity {
+        public static int constructor = 0xc8cf05f8;
+
+        public long document_id;
+        public TLRPC.Document document; // custom
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            offset = stream.readInt32(exception);
+            length = stream.readInt32(exception);
+            document_id = stream.readInt64(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(offset);
+            stream.writeInt32(length);
+            stream.writeInt64(document_id);
+        }
+    }
+
+    public static class TL_messages_getCustomEmojiDocuments extends TLObject {
+        public static int constructor = 0xd9ab0f54;
+
+        public ArrayList<Long> document_id = new ArrayList<>();
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            Vector vector = new Vector();
+            int size = stream.readInt32(exception);
+            for (int a = 0; a < size; a++) {
+                Document object = Document.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return vector;
+                }
+                vector.objects.add(object);
+            }
+            return vector;
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(0x1cb5c415);
+            int count = document_id.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                stream.writeInt64(document_id.get(a));
+            }
+        }
+    }
+
+    public static abstract class ChatReactions extends TLObject {
+
+        public static ChatReactions TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+            ChatReactions result = null;
+            switch (constructor) {
+                case 0x661d4037:
+                    result = new TL_chatReactionsSome();
+                    break;
+                case 0xeafc32bc:
+                    result = new TL_chatReactionsNone();
+                    break;
+                case 0x52928bca:
+                    result = new TL_chatReactionsAll();
+                    break;
+            }
+            if (result == null && exception) {
+                throw new RuntimeException(String.format("can't parse magic %x in ChatReactions", constructor));
+            }
+            if (result != null) {
+                result.readParams(stream, exception);
+            }
+            return result;
+        }
+    }
+
+    public static class TL_chatReactionsSome extends ChatReactions {
+        public static int constructor = 0x661d4037;
+
+        public ArrayList<Reaction> reactions = new ArrayList<>();
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            int magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            int count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                Reaction object = Reaction.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                reactions.add(object);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(0x1cb5c415);
+            int count = reactions.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                reactions.get(a).serializeToStream(stream);
+            }
+        }
+    }
+
+    public static class TL_chatReactionsNone extends ChatReactions {
+        public static int constructor = 0xeafc32bc;
+
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
+    public static class TL_chatReactionsAll extends ChatReactions {
+        public static int constructor = 0x52928bca;
+
+        public int flags;
+        public boolean allow_custom;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            allow_custom = (flags & 1) != 0;
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = allow_custom ? (flags | 1) : (flags & ~1);
+            stream.writeInt32(flags);
+        }
+    }
+
+    public static class TL_messages_reportReaction extends TLObject {
+        public static int constructor = 0x61422a48;
+
+        public InputPeer peer;
+        public int id;
+        public InputUser user_id;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Bool.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            peer.serializeToStream(stream);
+            stream.writeInt32(id);
+            user_id.serializeToStream(stream);
+        }
+    }
+
+    public static class TL_messages_clearRecentReactions extends TLObject {
+        public static int constructor = 0x9dfeefb4;
+
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Bool.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
+    public static abstract class messages_Reactions extends TLObject {
+
+        public static messages_Reactions TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
+            messages_Reactions result = null;
+            switch (constructor) {
+                case 0xb06fdbdf:
+                    result = new TL_messages_reactionsNotModified();
+                    break;
+                case 0xeafdf716:
+                    result = new TL_messages_reactions();
+                    break;
+            }
+            if (result == null && exception) {
+                throw new RuntimeException(String.format("can't parse magic %x in messages_Reactions", constructor));
+            }
+            if (result != null) {
+                result.readParams(stream, exception);
+            }
+            return result;
+        }
+    }
+
+    public static class TL_messages_reactionsNotModified extends messages_Reactions {
+        public static int constructor = 0xb06fdbdf;
+
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
+    public static class TL_messages_reactions extends messages_Reactions {
+        public static int constructor = 0xeafdf716;
+
+        public long hash;
+        public ArrayList<Reaction> reactions = new ArrayList<>();
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            hash = stream.readInt64(exception);
+            int magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            int count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                Reaction object = Reaction.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                reactions.add(object);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt64(hash);
+            stream.writeInt32(0x1cb5c415);
+            int count = reactions.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                reactions.get(a).serializeToStream(stream);
+            }
+        }
+    }
+
+    public static class TL_messages_getTopReactions extends TLObject {
+        public static int constructor = 0xbb8125ba;
+
+        public int limit;
+        public long hash;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return messages_Reactions.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(limit);
+            stream.writeInt64(hash);
+        }
+    }
+
+    public static class TL_messages_getRecentReactions extends TLObject {
+        public static int constructor = 0x39461db2;
+
+        public int limit;
+        public long hash;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return messages_Reactions.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(limit);
+            stream.writeInt64(hash);
+        }
+    }
+
+    public static abstract class ForumTopic extends TLObject {
+
+        public static ForumTopic TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+            ForumTopic result = null;
+            switch (constructor) {
+                case 0x23f109b:
+                    result = new TL_forumTopicDeleted();
+                    break;
+                case 0x5920d6dc:
+                    result = new TL_forumTopic_layer147();
+                    break;
+                case 0x71701da9:
+                    result = new TL_forumTopic();
+                    break;
+            }
+            if (result == null && exception) {
+                throw new RuntimeException(String.format("can't parse magic %x in ForumTopic", constructor));
+            }
+            if (result != null) {
+                result.readParams(stream, exception);
+            }
+            return result;
+        }
+    }
+
+    public static class TL_forumTopicDeleted extends TL_forumTopic {
+        public static int constructor = 0x23f109b;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            id = stream.readInt32(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(id);
+        }
+    }
+
+    public static class TL_forumTopic_layer147 extends TL_forumTopic {
+        public static int constructor = 0x5920d6dc;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            my = (flags & 2) != 0;
+            closed = (flags & 4) != 0;
+            pinned = (flags & 8) != 0;
+            id = stream.readInt32(exception);
+            date = stream.readInt32(exception);
+            title = stream.readString(exception);
+            icon_color = stream.readInt32(exception);
+            if ((flags & 1) != 0) {
+                icon_emoji_id = stream.readInt64(exception);
+            }
+            top_message = stream.readInt32(exception);
+            read_inbox_max_id = stream.readInt32(exception);
+            read_outbox_max_id = stream.readInt32(exception);
+            unread_count = stream.readInt32(exception);
+            unread_mentions_count = stream.readInt32(exception);
+            unread_reactions_count = stream.readInt32(exception);
+            from_id = Peer.TLdeserialize(stream, stream.readInt32(exception), exception);
+            notify_settings = PeerNotifySettings.TLdeserialize(stream, stream.readInt32(exception), exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = my ? (flags | 2) : (flags & ~2);
+            flags = closed ? (flags | 4) : (flags & ~4);
+            flags = pinned ? (flags | 8) : (flags & ~8);
+            stream.writeInt32(flags);
+            stream.writeInt32(id);
+            stream.writeInt32(date);
+            stream.writeString(title);
+            stream.writeInt32(icon_color);
+            if ((flags & 1) != 0) {
+                stream.writeInt64(icon_emoji_id);
+            }
+            stream.writeInt32(top_message);
+            stream.writeInt32(read_inbox_max_id);
+            stream.writeInt32(read_outbox_max_id);
+            stream.writeInt32(unread_count);
+            stream.writeInt32(unread_mentions_count);
+            stream.writeInt32(unread_reactions_count);
+            from_id.serializeToStream(stream);
+            notify_settings.serializeToStream(stream);
+        }
+    }
+
+    public static class TL_forumTopic extends ForumTopic {
+        public static int constructor = 0x71701da9;
+
+        public int flags;
+        public boolean my;
+        public boolean closed;
+        public boolean pinned;
+        public boolean isShort;
+        public boolean hidden;
+        public int id;
+        public int date;
+        public String title;
+        public int icon_color;
+        public long icon_emoji_id;
+        public int top_message;
+        public int read_inbox_max_id;
+        public int read_outbox_max_id;
+        public int unread_count;
+        public int unread_mentions_count;
+        public int unread_reactions_count;
+        public Peer from_id;
+        public PeerNotifySettings notify_settings;
+        public DraftMessage draft;
+        public Message topicStartMessage; // custom
+        public ArrayList<MessageObject> groupedMessages; // custom
+        public Message topMessage; // custom
+        public String searchQuery; // custom
+        public int pinnedOrder; // custom
+        public int totalMessagesCount; // custom
+
+        public static TL_forumTopic TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+            TL_forumTopic result = null;
+            switch (constructor) {
+                case 0x23f109b:
+                    result = new TL_forumTopicDeleted();
+                    break;
+                case 0x5920d6dc:
+                    result = new TL_forumTopic_layer147();
+                    break;
+                case 0x71701da9:
+                    result = new TL_forumTopic();
+                    break;
+            }
+            if (result == null && exception) {
+                throw new RuntimeException(String.format("can't parse magic %x in TL_forumTopic", constructor));
+            }
+            if (result != null) {
+                result.readParams(stream, exception);
+            }
+            return result;
+        }
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            my = (flags & 2) != 0;
+            closed = (flags & 4) != 0;
+            pinned = (flags & 8) != 0;
+            isShort = (flags & 32) != 0;
+            hidden = (flags & 64) != 0;
+            id = stream.readInt32(exception);
+            date = stream.readInt32(exception);
+            title = stream.readString(exception);
+            icon_color = stream.readInt32(exception);
+            if ((flags & 1) != 0) {
+                icon_emoji_id = stream.readInt64(exception);
+            }
+            top_message = stream.readInt32(exception);
+            read_inbox_max_id = stream.readInt32(exception);
+            read_outbox_max_id = stream.readInt32(exception);
+            unread_count = stream.readInt32(exception);
+            unread_mentions_count = stream.readInt32(exception);
+            unread_reactions_count = stream.readInt32(exception);
+            from_id = Peer.TLdeserialize(stream, stream.readInt32(exception), exception);
+            notify_settings = PeerNotifySettings.TLdeserialize(stream, stream.readInt32(exception), exception);
+            if ((flags & 16) != 0) {
+                draft = DraftMessage.TLdeserialize(stream, stream.readInt32(exception), exception);
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = my ? (flags | 2) : (flags & ~2);
+            flags = closed ? (flags | 4) : (flags & ~4);
+            flags = pinned ? (flags | 8) : (flags & ~8);
+            flags = isShort ? (flags | 32) : (flags & ~32);
+            flags = hidden ? (flags | 64) : (flags & ~64);
+            stream.writeInt32(flags);
+            stream.writeInt32(id);
+            stream.writeInt32(date);
+            stream.writeString(title);
+            stream.writeInt32(icon_color);
+            if ((flags & 1) != 0) {
+                stream.writeInt64(icon_emoji_id);
+            }
+            stream.writeInt32(top_message);
+            stream.writeInt32(read_inbox_max_id);
+            stream.writeInt32(read_outbox_max_id);
+            stream.writeInt32(unread_count);
+            stream.writeInt32(unread_mentions_count);
+            stream.writeInt32(unread_reactions_count);
+            from_id.serializeToStream(stream);
+            notify_settings.serializeToStream(stream);
+            if ((flags & 16) != 0) {
+                draft.serializeToStream(stream);
+            }
+        }
+    }
+
+    public static class TL_messages_forumTopics extends TLObject {
+        public static int constructor = 0x367617d3;
+
+        public int flags;
+        public boolean order_by_create_date;
+        public int count;
+        public ArrayList<TL_forumTopic> topics = new ArrayList<>();
+        public ArrayList<Message> messages = new ArrayList<>();
+        public ArrayList<Chat> chats = new ArrayList<>();
+        public ArrayList<User> users = new ArrayList<>();
+        public int pts;
+
+        public static TL_messages_forumTopics TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
+            if (TL_messages_forumTopics.constructor != constructor) {
+                if (exception) {
+                    throw new RuntimeException(
+                            String.format("can't parse magic %x in TL_messages_forumTopics", constructor));
+                } else {
+                    return null;
+                }
+            }
+            TL_messages_forumTopics result = new TL_messages_forumTopics();
+            result.readParams(stream, exception);
+            return result;
+        }
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            order_by_create_date = (flags & 1) != 0;
+            count = stream.readInt32(exception);
+            int magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            int count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                TL_forumTopic object = TL_forumTopic.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                topics.add(object);
+            }
+            magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                Message object = Message.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                messages.add(object);
+            }
+            magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                Chat object = Chat.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                chats.add(object);
+            }
+            magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                User object = User.TLdeserialize(stream, stream.readInt32(exception), exception);
+                if (object == null) {
+                    return;
+                }
+                users.add(object);
+            }
+            pts = stream.readInt32(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = order_by_create_date ? (flags | 1) : (flags & ~1);
+            stream.writeInt32(flags);
+            stream.writeInt32(count);
+            stream.writeInt32(0x1cb5c415);
+            int count = topics.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                topics.get(a).serializeToStream(stream);
+            }
+            stream.writeInt32(0x1cb5c415);
+            count = messages.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                messages.get(a).serializeToStream(stream);
+            }
+            stream.writeInt32(0x1cb5c415);
+            count = chats.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                chats.get(a).serializeToStream(stream);
+            }
+            stream.writeInt32(0x1cb5c415);
+            count = users.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                users.get(a).serializeToStream(stream);
+            }
+            stream.writeInt32(pts);
+        }
+    }
+
+    public static class TL_channels_toggleForum extends TLObject {
+        public static int constructor = 0xa4298b29;
+
+        public InputChannel channel;
+        public boolean enabled;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Updates.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            channel.serializeToStream(stream);
+            stream.writeBool(enabled);
+        }
+    }
+
+    public static class TL_channels_createForumTopic extends TLObject {
+        public static int constructor = 0xf40c0224;
+
+        public int flags;
+        public InputChannel channel;
+        public String title;
+        public int icon_color;
+        public long icon_emoji_id;
+        public long random_id;
+        public InputPeer send_as;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Updates.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(flags);
+            channel.serializeToStream(stream);
+            stream.writeString(title);
+            if ((flags & 1) != 0) {
+                stream.writeInt32(icon_color);
+            }
+            if ((flags & 8) != 0) {
+                stream.writeInt64(icon_emoji_id);
+            }
+            stream.writeInt64(random_id);
+            if ((flags & 4) != 0) {
+                send_as.serializeToStream(stream);
+            }
+        }
+    }
+
+    public static class TL_channels_editForumTopic extends TLObject {
+        public static int constructor = 0xf4dfa185;
+
+        public int flags;
+        public InputChannel channel;
+        public int topic_id;
+        public String title;
+        public long icon_emoji_id;
+        public boolean closed;
+        public boolean hidden;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Updates.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(flags);
+            channel.serializeToStream(stream);
+            stream.writeInt32(topic_id);
+            if ((flags & 1) != 0) {
+                stream.writeString(title);
+            }
+            if ((flags & 2) != 0) {
+                stream.writeInt64(icon_emoji_id);
+            }
+            if ((flags & 4) != 0) {
+                stream.writeBool(closed);
+            }
+            if ((flags & 8) != 0) {
+                stream.writeBool(hidden);
+            }
+        }
+    }
+
+    public static class TL_channels_updatePinnedForumTopic extends TLObject {
+        public static int constructor = 0x6c2d9026;
+
+        public InputChannel channel;
+        public int topic_id;
+        public boolean pinned;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Updates.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            channel.serializeToStream(stream);
+            stream.writeInt32(topic_id);
+            stream.writeBool(pinned);
+        }
+    }
+
+    public static class TL_channels_getForumTopics extends TLObject {
+        public static int constructor = 0xde560d1;
+
+        public int flags;
+        public InputChannel channel;
+        public String q;
+        public int offset_date;
+        public int offset_id;
+        public int offset_topic;
+        public int limit;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return TL_messages_forumTopics.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(flags);
+            channel.serializeToStream(stream);
+            if ((flags & 1) != 0) {
+                stream.writeString(q);
+            }
+            stream.writeInt32(offset_date);
+            stream.writeInt32(offset_id);
+            stream.writeInt32(offset_topic);
+            stream.writeInt32(limit);
+        }
+    }
+
+    public static class TL_channels_getForumTopicsByID extends TLObject {
+        public static int constructor = 0xb0831eb9;
+
+        public InputChannel channel;
+        public ArrayList<Integer> topics = new ArrayList<>();
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return TL_messages_forumTopics.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            channel.serializeToStream(stream);
+            stream.writeInt32(0x1cb5c415);
+            int count = topics.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                stream.writeInt32(topics.get(a));
+            }
+        }
+    }
+
+    public static class TL_username extends TLObject {
+        public static int constructor = 0xb4073647;
+
+        public int flags;
+        public boolean editable;
+        public boolean active;
+        public String username;
+
+        public static TL_username TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+            if (TL_username.constructor != constructor) {
+                if (exception) {
+                    throw new RuntimeException(String.format("can't parse magic %x in TL_username", constructor));
+                } else {
+                    return null;
+                }
+            }
+            TL_username result = new TL_username();
+            result.readParams(stream, exception);
+            return result;
+        }
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            flags = stream.readInt32(exception);
+            editable = (flags & 1) != 0;
+            active = (flags & 2) != 0;
+            username = stream.readString(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = editable ? (flags | 1) : (flags & ~1);
+            flags = active ? (flags | 2) : (flags & ~2);
+            stream.writeInt32(flags);
+            stream.writeString(username);
+        }
+    }
+    public static class TL_channels_deleteTopicHistory extends TLObject {
+        public static int constructor = 0x34435f2d;
+
+        public InputChannel channel;
+        public int top_msg_id;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return TL_messages_affectedHistory.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            channel.serializeToStream(stream);
+            stream.writeInt32(top_msg_id);
+        }
+    }
+
+    public static class TL_account_reorderUsernames extends TLObject {
+        public static int constructor = 0xef500eab;
+
+        public ArrayList<String> order = new ArrayList<>();
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Bool.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(0x1cb5c415);
+            int count = order.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                stream.writeString(order.get(a));
+            }
+        }
+    }
+
+    public static class TL_account_toggleUsername extends TLObject {
+        public static int constructor = 0x58d6b376;
+
+        public String username;
+        public boolean active;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Bool.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeString(username);
+            stream.writeBool(active);
+        }
+    }
+
+    public static class TL_channels_reorderUsernames extends TLObject {
+        public static int constructor = 0xb45ced1d;
+
+        public InputChannel channel;
+        public ArrayList<String> order = new ArrayList<>();
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Bool.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            channel.serializeToStream(stream);
+            stream.writeInt32(0x1cb5c415);
+            int count = order.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                stream.writeString(order.get(a));
+            }
+        }
+    }
+
+    public static class TL_channels_toggleUsername extends TLObject {
+        public static int constructor = 0x50f24105;
+
+        public InputChannel channel;
+        public String username;
+        public boolean active;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Bool.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            channel.serializeToStream(stream);
+            stream.writeString(username);
+            stream.writeBool(active);
+        }
+    }
+
+    public static class TL_channels_deactivateAllUsernames extends TLObject {
+        public static int constructor = 0xa245dd3;
+
+        public InputChannel channel;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Bool.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            channel.serializeToStream(stream);
+        }
+    }
+
+    public static class TL_channels_reorderPinnedForumTopics extends TLObject {
+        public static int constructor = 0x2950a18f;
+
+        public int flags;
+        public boolean force;
+        public InputChannel channel;
+        public ArrayList<Integer> order = new ArrayList<>();
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Updates.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = force ? (flags | 1) : (flags & ~1);
+            stream.writeInt32(flags);
+            channel.serializeToStream(stream);
+            stream.writeInt32(0x1cb5c415);
+            int count = order.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                stream.writeInt32(order.get(a));
+            }
+        }
+    }
+
+    public static class TL_channels_toggleAntiSpam extends TLObject {
+        public static int constructor = 0x68f3e4eb;
+
+        public InputChannel channel;
+        public boolean enabled;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Updates.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            channel.serializeToStream(stream);
+            stream.writeBool(enabled);
+        }
+    }
+
+    public static class TL_channels_reportAntiSpamFalsePositive extends TLObject {
+        public static int constructor = 0xa850a693;
+
+        public InputChannel channel;
+        public int msg_id;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Bool.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            channel.serializeToStream(stream);
+            stream.writeInt32(msg_id);
+        }
+    }
+
+    public static class TL_channels_toggleParticipantsHidden extends TLObject {
+        public static int constructor = 0x6a6e7854;
+
+        public InputChannel channel;
+        public boolean enabled;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Updates.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            channel.serializeToStream(stream);
+            stream.writeBool(enabled);
+        }
+    }
+
+    public static class TL_messages_setDefaultHistoryTTL extends TLObject {
+        public static int constructor = 0x9eb51445;
+
+        public int period;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Bool.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(period);
+        }
+    }
+
+    public static class TL_messages_getDefaultHistoryTTL extends TLObject {
+        public static int constructor = 0x658b7188;
+
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return TL_defaultHistoryTTL.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
+    public static class TL_defaultHistoryTTL extends TLObject {
+        public static int constructor = 0x43b46b20;
+
+        public int period;
+
+        public static TL_defaultHistoryTTL TLdeserialize(AbstractSerializedData stream, int constructor,
+                boolean exception) {
+            if (TL_defaultHistoryTTL.constructor != constructor) {
+                if (exception) {
+                    throw new RuntimeException(
+                            String.format("can't parse magic %x in TL_defaultHistoryTTL", constructor));
+                } else {
+                    return null;
+                }
+            }
+            TL_defaultHistoryTTL result = new TL_defaultHistoryTTL();
+            result.readParams(stream, exception);
+            return result;
+        }
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            period = stream.readInt32(exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(period);
+        }
+    }
+
+    public static class TL_messages_sendBotRequestedPeer extends TLObject {
+        public static int constructor = 0xfe38d01b;
+
+        public InputPeer peer;
+        public int msg_id;
+        public int button_id;
+        public InputPeer requested_peer;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return Updates.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            peer.serializeToStream(stream);
+            stream.writeInt32(msg_id);
+            stream.writeInt32(button_id);
+            requested_peer.serializeToStream(stream);
+        }
+    }
+
+    public static class TL_contacts_exportContactToken extends TLObject {
+        public static int constructor = 0xf8654027;
+
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return TL_exportedContactToken.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
+    public static class TL_contacts_importContactToken extends TLObject {
+        public static int constructor = 0x13005788;
+
+        public String token;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return User.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeString(token);
+        }
+    }
+
+    public static class TL_messageActionSuggestProfilePhoto extends MessageAction {
+        public static int constructor = 0x57de635e;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            photo = Photo.TLdeserialize(stream, stream.readInt32(exception), exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            photo.serializeToStream(stream);
+        }
+    }
+
+    public static class TL_messageActionAttachMenuBotAllowed extends MessageAction {
+        public static int constructor = 0xe7e75f97;
+
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
+    public static class TL_messageActionRequestedPeer extends MessageAction {
+        public static int constructor = 0xfe77345d;
+
+        public int button_id;
+        public TLRPC.Peer peer;
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            button_id = stream.readInt32(exception);
+            peer = TLRPC.Peer.TLdeserialize(stream, stream.readInt32(exception), exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt32(button_id);
+            peer.serializeToStream(stream);
+        }
+    }
+
+    public static class TL_photos_uploadContactProfilePhoto extends TLObject {
+        public static int constructor = 0xe14c4a71;
+
+        public int flags;
+        public boolean suggest;
+        public boolean save;
+        public InputUser user_id;
+        public InputFile file;
+        public InputFile video;
+        public double video_start_ts;
+        public VideoSize video_emoji_markup;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return TL_photos_photo.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            flags = suggest ? (flags | 8) : (flags & ~8);
+            flags = save ? (flags | 16) : (flags & ~16);
+            stream.writeInt32(flags);
+            user_id.serializeToStream(stream);
+            if ((flags & 1) != 0) {
+                file.serializeToStream(stream);
+            }
+            if ((flags & 2) != 0) {
+                video.serializeToStream(stream);
+            }
+            if ((flags & 4) != 0) {
+                stream.writeDouble(video_start_ts);
+            }
+            if ((flags & 32) != 0) {
+                video_emoji_markup.serializeToStream(stream);
+            }
+        }
+    }
+
+    public static abstract class EmojiList extends TLObject {
+
+        public static EmojiList TLdeserialize(AbstractSerializedData stream, int constructor, boolean exception) {
+            EmojiList result = null;
+            switch (constructor) {
+                case 0x7a1e11d1:
+                    result = new TL_emojiList();
+                    break;
+                case 0x481eadfa:
+                    result = new TL_emojiListNotModified();
+                    break;
+            }
+            if (result == null && exception) {
+                throw new RuntimeException(String.format("can't parse magic %x in EmojiList", constructor));
+            }
+            if (result != null) {
+                result.readParams(stream, exception);
+            }
+            return result;
+        }
+    }
+
+    public static class TL_emojiList extends EmojiList {
+        public static int constructor = 0x7a1e11d1;
+
+        public long hash;
+        public ArrayList<Long> document_id = new ArrayList<>();
+
+        public void readParams(AbstractSerializedData stream, boolean exception) {
+            hash = stream.readInt64(exception);
+            int magic = stream.readInt32(exception);
+            if (magic != 0x1cb5c415) {
+                if (exception) {
+                    throw new RuntimeException(String.format("wrong Vector magic, got %x", magic));
+                }
+                return;
+            }
+            int count = stream.readInt32(exception);
+            for (int a = 0; a < count; a++) {
+                document_id.add(stream.readInt64(exception));
+            }
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt64(hash);
+            stream.writeInt32(0x1cb5c415);
+            int count = document_id.size();
+            stream.writeInt32(count);
+            for (int a = 0; a < count; a++) {
+                stream.writeInt64(document_id.get(a));
+            }
+        }
+    }
+
+    public static class TL_emojiListNotModified extends EmojiList {
+        public static int constructor = 0x481eadfa;
+
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+        }
+    }
+
+    public static class TL_account_getDefaultProfilePhotoEmojis extends TLObject {
+        public static int constructor = 0xe2750328;
+
+        public long hash;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return EmojiList.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt64(hash);
+        }
+    }
+
+    public static class TL_account_getDefaultGroupPhotoEmojis extends TLObject {
+        public static int constructor = 0x915860ae;
+
+        public long hash;
+
+        public TLObject deserializeResponse(AbstractSerializedData stream, int constructor, boolean exception) {
+            return EmojiList.TLdeserialize(stream, constructor, exception);
+        }
+
+        public void serializeToStream(AbstractSerializedData stream) {
+            stream.writeInt32(constructor);
+            stream.writeInt64(hash);
+        }
+    }
+
     //functions
 
     public static class Vector extends TLObject {
         public static int constructor = 0x1cb5c415;
         public ArrayList<Object> objects = new ArrayList<>();
     }
+
 }

--- a/telegram-decoder-impl/src/main/java/telegramdecoder/DecoderTelegram.java
+++ b/telegram-decoder-impl/src/main/java/telegramdecoder/DecoderTelegram.java
@@ -170,9 +170,19 @@ public class DecoderTelegram implements DecoderTelegramInterface{
                 if (message.getData() != null && !message.getData().trim().isEmpty()) {
                     msgDataAndSeparator = message.getData().trim() + " | ";
                 }
+                if (m.media.extended_media != null
+                        && m.media.extended_media instanceof TLRPC.TL_messageExtendedMediaPreview) {
+                    TLRPC.TL_messageExtendedMediaPreview preview = (TLRPC.TL_messageExtendedMediaPreview) m.media.extended_media;
+                    message.setThumb(preview.thumb.bytes);
+                    
+                }
                 if(m.media.document!=null) {
                     if(m.media.document instanceof TLRPC.TL_documentEmpty){
                         message.setData(msgDataAndSeparator + "Empty media");
+                    }
+
+                    if (m.media.document.thumbs != null && m.media.document.thumbs.size() > 0) {
+                        message.setThumb(m.media.document.thumbs.get(0).bytes);
                     }
                     message.setMediaMime(m.media.document.mime_type);
                 }else
@@ -182,31 +192,29 @@ public class DecoderTelegram implements DecoderTelegramInterface{
                 }else
                 if(m.media.webpage!=null) {
                     message.setLink(true);
+                    try {
+                        message.setThumb(m.media.webpage.cached_page.documents.get(0).thumbs.get(0).bytes);
+                    } catch (Exception e) {
+                        message.setThumb(null);
+                    }
                     message.setMediaMime("link");
 
-                }else
-                if(m.media.description!=null){
+                } else if (m.media.description != null) {
                     message.setData(msgDataAndSeparator + "Desc: "+m.media.description);
-                }else
-                if(m.media.game!=null){
+                } else if (m.media.game != null) {
                     message.setData(msgDataAndSeparator + "Game: "+m.media.game.title);
-                }else
-                if(m.media.geo!=null){
+                } else if (m.media.geo != null) {
                     message.setLatitude(m.media.geo.lat);
                     message.setLongitude(m.media.geo._long);
                     message.setMediaMime("geo");
-                }else                
-                if(m.media.vcard!=null){
+                } else if (m.media.vcard != null) {
                     message.setData(msgDataAndSeparator + "Vcard: "+m.media.vcard);
-                }else
-                if(m.media.phone_number!=null){
+                } else if (m.media.phone_number != null) {
                     message.setData(msgDataAndSeparator + "Phone: "+m.media.phone_number);
-                }else
-                if(m.media instanceof TLRPC.TL_messageMediaEmpty){
+                } else if (m.media instanceof TLRPC.TL_messageMediaEmpty) {
                     //ignore see https://github.com/sepinf-inc/IPED/issues/1454
                     //message.setData(message.getData()+" Empty media");
-                }else
-                if(m.media instanceof TLRPC.TL_messageMediaPoll){
+                } else if (m.media instanceof TLRPC.TL_messageMediaPoll) {
                     TLRPC.TL_messageMediaPoll mpool=(TLRPC.TL_messageMediaPoll)m.media;
                     String text = "Pool: " + mpool.poll.question;
                     int i = 0;

--- a/telegram-decoder-impl/src/main/java/telegramdecoder/DecoderTelegram.java
+++ b/telegram-decoder-impl/src/main/java/telegramdecoder/DecoderTelegram.java
@@ -6,29 +6,24 @@
 package telegramdecoder;
 
 
+import java.lang.reflect.Field;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.telegram.tgnet.SerializedData;
+import org.telegram.tgnet.TLRPC;
+import org.telegram.tgnet.TLRPC.DocumentAttribute;
+
 import dpf.ap.gpinf.interfacetelegram.ContactInterface;
 import dpf.ap.gpinf.interfacetelegram.DecoderTelegramInterface;
 import dpf.ap.gpinf.interfacetelegram.MessageInterface;
 import dpf.ap.gpinf.interfacetelegram.PhotoData;
-import java.lang.reflect.Field;
-
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import org.telegram.tgnet.SerializedData;
-import org.telegram.tgnet.TLObject;
-import org.telegram.tgnet.TLRPC;
-import org.telegram.tgnet.TLRPC.DocumentAttribute; 
 
 /**
  *
@@ -44,9 +39,10 @@ public class DecoderTelegram implements DecoderTelegramInterface{
     public void setDecoderData(byte[] data,int TYPE) {
         SerializedData s=new SerializedData(data);
         int aux=s.readInt32(false);
-        m=null;
-        u=null;
-        c=null;
+        m = null;
+        u = null;
+        c = null;
+        cf = null;
         if(TYPE==MESSAGE){
             m=TLRPC.Message.TLdeserialize(s,aux, false);
         }
@@ -239,6 +235,7 @@ public class DecoderTelegram implements DecoderTelegramInterface{
     	                
     }
 
+
     @Override
     public void getChatData(ContactInterface chat) {
         if(chat!=null && c!=null){
@@ -247,9 +244,20 @@ public class DecoderTelegram implements DecoderTelegramInterface{
             chat.setName(c.title);
             chat.setLastName(null);
             chat.setPhone(null);
-            
         }
         
+    }
+
+    @Override
+    public Map<String, Object> getAlltMetadata() {
+        Map<String, Object> other = new TreeMap<>();
+
+        Util.fieldsToMap(other, this.c);
+        Util.fieldsToMap(other, cf);
+        Util.fieldsToMap(other, this.u);
+        Util.fieldsToMap(other, this.m);
+
+        return other;
     }
 
     

--- a/telegram-decoder-impl/src/main/java/telegramdecoder/Util.java
+++ b/telegram-decoder-impl/src/main/java/telegramdecoder/Util.java
@@ -1,0 +1,41 @@
+package telegramdecoder;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class Util {
+    public static List<Field> getAllFields(Class clazz) {
+        if (clazz == null) {
+            return Collections.emptyList();
+        }
+
+        List<Field> result = new ArrayList<>(getAllFields(clazz.getSuperclass()));
+        List<Field> filteredFields = Arrays.stream(clazz.getDeclaredFields())
+                .filter(f -> Modifier.isPublic(f.getModifiers()) || Modifier.isProtected(f.getModifiers()))
+                .collect(Collectors.toList());
+        result.addAll(filteredFields);
+        return result;
+    }
+
+    public static void fieldsToMap(Map<String, Object> other, Object o) {
+        if (o == null) {
+            return;
+        }
+        List<Field> fields = getAllFields(o.getClass());
+
+        for (Field f : fields) {
+            try {
+                other.put(f.getName(), f.get(o));
+            } catch (IllegalArgumentException | IllegalAccessException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/telegram-decoder-impl/src/main/java/telegramdecoder/Util.java
+++ b/telegram-decoder-impl/src/main/java/telegramdecoder/Util.java
@@ -31,7 +31,10 @@ public class Util {
 
         for (Field f : fields) {
             try {
-                other.put(f.getName(), f.get(o));
+                Object val = f.get(o);
+                if (val != null) {
+                    other.put(f.getName(), val.toString());
+                }
             } catch (IllegalArgumentException | IllegalAccessException e) {
                 // TODO Auto-generated catch block
                 e.printStackTrace();


### PR DESCRIPTION
This adds a new method to return all the data decoded as a map. Additionally, the telegram library is updated to version 9.4.0, and a minor refactor to avoid editing the TLRPC.java file imported from [TLRPC.java](https://github.com/DrKLO/Telegram/blob/master/TMessagesProj/src/main/java/org/telegram/tgnet/TLRPC.java).